### PR TITLE
Apply new color scheme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,31 +9,31 @@
 
     --background: 0 0% 100%;
 
-    --foreground: 0 0% 3.9%;
+    --foreground: 0 0% 10%;
 
     --card: 0 0% 100%;
 
-    --card-foreground: 0 0% 3.9%;
+    --card-foreground: 0 0% 10%;
 
     --popover: 0 0% 100%;
 
-    --popover-foreground: 0 0% 3.9%;
+    --popover-foreground: 0 0% 10%;
 
-    --primary: 0 0% 9%;
+    --primary: 358.9 90.2% 63.9%;
 
-    --primary-foreground: 0 0% 98%;
+    --primary-foreground: 0 0% 100%;
 
     --secondary: 0 0% 96.1%;
 
-    --secondary-foreground: 0 0% 9%;
+    --secondary-foreground: 0 0% 10%;
 
     --muted: 0 0% 96.1%;
 
     --muted-foreground: 0 0% 45.1%;
 
-    --accent: 0 0% 96.1%;
+    --accent: 33 46% 91%;
 
-    --accent-foreground: 0 0% 9%;
+    --accent-foreground: 0 0% 10%;
 
     --destructive: 0 84.2% 60.2%;
 

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -34,7 +34,7 @@ const footerLinks = [
 
 const Footer = () => {
   return (
-    <footer className="dark:border-t mt-40 dark bg-background text-foreground">
+    <footer className="dark:border-t mt-40 dark bg-accent text-foreground">
       <div className="max-w-screen-xl mx-auto">
         <div className="py-12 flex flex-col sm:flex-row items-start justify-between gap-x-8 gap-y-10 px-6 xl:px-0">
           <div>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,7 +5,7 @@ import LogoCloud from "./logo-cloud";
 
 const Hero = () => {
   return (
-    <div className="min-h-[calc(100vh-6rem)] flex flex-col items-center py-20 px-6">
+    <div className="min-h-[calc(100vh-6rem)] flex flex-col items-center py-20 px-6 bg-accent">
       <div className="md:mt-6 flex items-center justify-center">
         <div className="text-center max-w-2xl">
           <h1 className="max-w-[20ch] mt-6 text-3xl xs:text-4xl sm:text-5xl md:text-6xl font-bold !leading-[1.2] tracking-tight">


### PR DESCRIPTION
## Summary
- tweak the Tailwind color palette for new brand colors
- use the accent color as the hero and footer background

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_685e86dd4140832d97a3e2643a2d9e7a