### PR TITLE
Update hero heading and fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,6 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
+@import url('https://api.fontshare.com/v2/css?f[]=clash-display@700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -120,5 +123,11 @@
   }
   body {
     @apply text-foreground;
+    font-family: 'Poppins', sans-serif;
+  }
+  h1, h2, h3, h4, h5, h6 {
+    font-family: 'Clash Display', sans-serif;
+    font-weight: 700;
+    text-transform: uppercase;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,12 @@
 import { TooltipProvider } from "@/components/ui/tooltip";
 import type { Metadata } from "next";
 import { ThemeProvider } from "next-themes";
-import { Geist } from "next/font/google";
+import { Poppins } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
+const poppins = Poppins({
   subsets: ["latin"],
+  weight: ["400", "700"],
 });
 
 export const metadata: Metadata = {
@@ -100,7 +101,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${geistSans.className} antialiased`}>
+      <body className={`${poppins.className} antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <TooltipProvider>{children}</TooltipProvider>
         </ThemeProvider>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -9,7 +9,7 @@ const Hero = () => {
       <div className="md:mt-6 flex items-center justify-center">
         <div className="text-center max-w-2xl">
           <h1 className="max-w-[20ch] mt-6 text-3xl xs:text-4xl sm:text-5xl md:text-6xl font-bold !leading-[1.2] tracking-tight">
-            EMS — The Guest Experience Engine, Unchained
+            The Guest Experience Engine
           </h1>
           <p className="mt-6 max-w-[60ch] xs:text-lg">
             Tired of missed room-service calls, endless follow-ups and generic feedback forms? EMS puts every guest touchpoint—ordering, service requests, live chat and in-moment reviews—into a single, white-label mobile interface. No apps to download, no software to master. Just scan, serve, sell and scale.


### PR DESCRIPTION
## Summary
- load Poppins and Clash Display fonts
- set body font to Poppins and headings to Clash Display in globals
- use Poppins font in layout
- update hero heading text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685e88dcddf8832d9a5052939b25d164