### PR TITLE
Add content for EMS product and industry pages

### DIFF
--- a/app/ems-rate/page.tsx
+++ b/app/ems-rate/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,42 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">EMS Rate</h1>
+        <PageHero
+          title="Capture feedback, grow loyalty, protect your reputation."
+          subtitle="Instant surveys, automated review requests, and AI-powered sentiment analysis—built for hospitality."
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <p>What you don’t know can hurt your brand. EMS Rate closes the loop fast:</p>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>In-service micro-surveys – Catch issues before checkout with one-tap ratings embedded in Wi-Fi portals, QR cards, or the EMS Serve interface.</li>
+            <li>Post-visit review booster – Automatically invite happy guests to share their experience on Google, TripAdvisor, and Booking.com.</li>
+            <li>AI sentiment & themes – Dashboards surface the trends behind your scores—menu variety, cleanliness, staff friendliness, and more.</li>
+            <li>Reputation reply hub – Respond to every public review from one screen, using suggested replies that match your tone.</li>
+            <li>Service recovery workflows – Route low scores to the right manager and trigger vouchers or follow-up calls automatically.</li>
+          </ul>
+          <p className="font-semibold">Properties using EMS Rate increase average review score by 0.7 stars in six months.</p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Close-the-Loop Workflow</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Real-time pulse – Micro-surveys fire during the stay; issues auto-create tasks in EMS Serve.</li>
+            <li>Review routing – Happy guests receive branded Google/TripAdvisor prompts; unhappy ones are taken to a private form.</li>
+            <li>Service recovery – Action plans auto-assign to the right manager with built-in SLA timers and escalation rules.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Why EMS Rate Beats Generic Survey Tools</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Designed for hospitality – Room, table, and ticket IDs link feedback to exact staff and shift.</li>
+            <li>Predictive alerts – AI flags at-risk guests before they leave the property.</li>
+            <li>Omni-language – Surveys localise to 30+ languages automatically.</li>
+            <li>Revenue reporting – See how a +0.1-star lift correlates to ADR or per-cover spend.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Own your online reputation: Schedule an EMS Rate walkthrough →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/ems-send/page.tsx
+++ b/app/ems-send/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,75 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">EMS Send</h1>
+        <PageHero
+          title="Send the right message at the perfect moment."
+          subtitle="Omni-channel guest engagement—email, SMS, WhatsApp, and push—driven by real-time data from EMS Serve."
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <p>Stop blasting one-size-fits-all emails and start meaningful conversations:</p>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Automated journeys – Welcome flows, mid-stay check-ins, abandoned-cart nudges, and re-engagement campaigns out of the box.</li>
+            <li>Smart segmentation – Target by first vs. repeat visit, spend tier, onsite behaviour, or custom tags.</li>
+            <li>True two-way messaging – Guests can reply in-channel; your team sees it all in one shared inbox.</li>
+            <li>Drag-and-drop builder – Gorgeous templates render flawlessly on every device—zero HTML required.</li>
+            <li>A/B/C testing & AI optimisation – Let the system find the subject lines, send-times, and offers that win.</li>
+          </ul>
+          <p className="font-semibold">Clients see an average 42 % lift in direct bookings within 90 days.</p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Lifecycle Journey Examples</h2>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-left border-collapse">
+              <thead>
+                <tr>
+                  <th className="p-2 border">Trigger</th>
+                  <th className="p-2 border">Channel</th>
+                  <th className="p-2 border">Example Message</th>
+                  <th className="p-2 border">Goal</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td className="p-2 border">Booking confirmed</td>
+                  <td className="p-2 border">Email</td>
+                  <td className="p-2 border">“We can’t wait to host you—upgrade to a harbour-view room for 20 % off.”</td>
+                  <td className="p-2 border">Upsell</td>
+                </tr>
+                <tr>
+                  <td className="p-2 border">Mid-stay day 2</td>
+                  <td className="p-2 border">WhatsApp</td>
+                  <td className="p-2 border">“How’s your stay so far? Reply 1-5.”</td>
+                  <td className="p-2 border">Real-time feedback</td>
+                </tr>
+                <tr>
+                  <td className="p-2 border">Abandoned checkout</td>
+                  <td className="p-2 border">SMS</td>
+                  <td className="p-2 border">“Still thinking it over? Here’s a 10 % code that expires tonight.”</td>
+                  <td className="p-2 border">Conversion</td>
+                </tr>
+                <tr>
+                  <td className="p-2 border">30 days post-stay</td>
+                  <td className="p-2 border">Email</td>
+                  <td className="p-2 border">“We miss you! Enjoy a complimentary dessert on your next visit.”</td>
+                  <td className="p-2 border">Repeat visit</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Compliance & Deliverability</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>100 % GDPR & CCPA ready – Automatic consent capture, granular preferences, and double opt-in.</li>
+            <li>Enterprise deliverability – Dedicated IP pools and automatic list hygiene for &gt; 99 % inbox placement.</li>
+            <li>Built-in preference centre – Let guests manage channels and frequency; keep churn below 0.8 %.</li>
+            <li>Audit trail – Every send, open, click, and unsubscribe is logged and exportable for regulators.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Turn every message into revenue: Start your free EMS Send trial →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/ems-serve/page.tsx
+++ b/app/ems-serve/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,46 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">EMS Serve</h1>
+        <PageHero
+          title="Serve every guest, every time—seamlessly."
+          subtitle="Elevate on-property service with real-time ordering, payments, and guest insights in one intuitive hub."
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <p>
+            Today’s guests expect ultra-fast, friction-free service from the moment they arrive. EMS Serve puts your entire front-of-house workflow on autopilot:
+          </p>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Digital ordering & payments – Guests scan, browse, customise, and pay in seconds—no app downloads, no waiting.</li>
+            <li>Live order routing – Orders flow straight to the right prep station or bar, with smart throttling to prevent back-of-house bottlenecks.</li>
+            <li>Adaptive menus – Update items, modifiers, prices, or imagery across every location in a single click.</li>
+            <li>Guest profiles – Build rich, GDPR-compliant profiles with spend history and preferences to personalise upsells in real time.</li>
+            <li>Analytics that matter – Track fulfilment times, item popularity, repeat-order rate, and staff performance on a single dashboard.</li>
+          </ul>
+          <p className="font-semibold">
+            Cut wait times by 38 %, boost average spend by 19 %, and free staff to focus on hospitality—not admin.
+          </p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">How EMS Serve Works</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Guest orders – They scan a QR code or tap an NFC tag, customise, and pay in under 30 seconds.</li>
+            <li>Smart routing – Our engine sends the ticket to the exact station (bar, kitchen, service desk) with built-in load balancing.</li>
+            <li>Delight & repeat – When the order is ready, guests get an instant text or screen alert—plus a one-tap reorder button that boosts repeat purchase by 14 %.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Plug-and-Play Integrations</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>POS & PMS – Toast, Lightspeed, Oracle, Opera, Mews, …</li>
+            <li>Payment gateways – Stripe, Adyen, Apple Pay, Google Pay, Pay by Bank.</li>
+            <li>IoT & hardware – Kitchen display systems, printers, kiosk screens, and digital signage.</li>
+            <li>Open API – Build custom apps or pull order data straight into your BI stack in minutes—no extra licence fees.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Ready to raise the bar? Book a live demo of EMS Serve →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/industries/airbnbs/page.tsx
+++ b/app/industries/airbnbs/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,43 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">Airbnbs</h1>
+        <PageHero
+          title="Scale your short-stay portfolio without scaling your workload."
+          subtitle=""
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Pre-stay welcome messages & smart lock PINs sent automatically.</li>
+            <li>Mid-stay check-ins catch issues before they hit review scores.</li>
+            <li>Housekeeper scheduling & photo proof inside EMS Serve.</li>
+            <li>EMS Rate auto-prompts 5-star guests and privately resolves negatives.</li>
+          </ul>
+          <p className="font-semibold">Hosts report 35 % fewer after-hours calls and a 0.5-star uplift on Airbnb within 60 days.</p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Full Guest Journey Timeline</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Booking +0 min – Instant confirmation with house manual link.</li>
+            <li>T-3 days – Smart lock PIN + driving directions.</li>
+            <li>Arrival evening – “Rate your check-in experience” micro-survey.</li>
+            <li>Mid-stay – Automated local-tips SMS and upsell for late checkout.</li>
+            <li>Checkout morning – Cleaning instructions + review prompt.</li>
+            <li>D +3 days – Loyalty email with next-stay discount.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Centralised Ops Dashboard</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Unified calendar – See bookings from Airbnb, Vrbo, Booking.com in one view.</li>
+            <li>Auto-scheduler – Housekeepers get tasks, checklists, and photo-proof uploads.</li>
+            <li>Issue tracker – Guest messages flagged with severity; urgent items push to on-call phone.</li>
+            <li>Owner reports – Monthly P&L, occupancy, and review scores delivered automatically.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Automate the guest journey—request a demo today →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/industries/hotels/page.tsx
+++ b/app/industries/hotels/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,45 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">Hotels</h1>
+        <PageHero
+          title="From lobby to late checkout, craft stays guests rave about."
+          subtitle=""
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <p className="font-semibold">Pain points</p>
+          <p>Long queues at reception, fragmented comms, OTA dependency, negative reviews.</p>
+          <p className="font-semibold">Solution narrative</p>
+          <p>EMS unifies operations and guest engagement, so front-desk teams spend less time clicking screens and more time creating memorable moments.</p>
+          <h2 className="text-2xl font-semibold">Key benefits</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Mobile check-in & keyless entry codes sent via EMS Send.</li>
+            <li>Upsell add-ons—late checkout, spa, dining—delivered contextually through EMS Serve.</li>
+            <li>Real-time housekeeping updates reduce room-ready delays by 25 %.</li>
+            <li>Automated review invites via EMS Rate amplify direct booking credibility.</li>
+          </ul>
+          <p className="italic">“Within 90 days we saw a 15 % uplift in direct bookings and a dramatic fall in reception wait times.” — General Manager, The London Harbour Hotel</p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Guest Journey Touchpoints</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Pre-arrival – Automated upsell emails for room upgrades, spa, or parking.</li>
+            <li>Check-in – Mobile key + digital registration in under two minutes.</li>
+            <li>In-stay – One-tap room-service ordering via EMS Serve.</li>
+            <li>Checkout – Express bill review & payment; review invite triggered instantly.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Results You Can Count On</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>28 % reduction in front-desk queue times within 60 days.</li>
+            <li>19 % increase in guest spend on ancillaries (late checkout, F&B, spa).</li>
+            <li>0.6-star lift in average review rating across major OTAs by month 4.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Unlock next-level guest satisfaction → Talk to our hotel specialists</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/industries/restaurants/page.tsx
+++ b/app/industries/restaurants/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,40 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">Restaurants</h1>
+        <PageHero
+          title="Seat more diners, turn tables faster, and keep them coming back."
+          subtitle=""
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <ul className="list-disc pl-5 space-y-2">
+            <li>QR-code menus & table ordering slash average dwell time by 12 minutes.</li>
+            <li>Real-time menu 86ing prevents disappointing ‘Sorry, we’re out’ moments.</li>
+            <li>EMS Send remarketing fills slow shifts with targeted lunch offers.</li>
+            <li>EMS Rate flags service issues the same evening—before they become 1-star posts.</li>
+          </ul>
+          <p className="font-semibold">Restaurants using EMS cut walk-outs by 18 % and grow per-cover spend by 22 % in the first quarter.</p>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">From Seat to Repeat – Workflow</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Seat – Host stands scan QR to assign table and server.</li>
+            <li>Order & pay – Guests split bills, tip, and reorder without flagging staff.</li>
+            <li>Feedback – Instant 5-second survey before they leave.</li>
+            <li>Retarget – Hyper-local lunch offer arrives the next weekday.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Loyalty & CRM Booster</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Card-free points – Spend automatically logs to a profile; rewards trigger via EMS Send.</li>
+            <li>Guest DNA – Dietary tags, preferred wines, and last-visit dishes surface for staff in real time.</li>
+            <li>Win-back automations – Guests who’ve lapsed 60 days get a personalised offer proven to recapture 23 % of dormant diners.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">Book a tasting tour of EMS for restaurants →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/industries/venues/page.tsx
+++ b/app/industries/venues/page.tsx
@@ -1,4 +1,6 @@
+import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 
 export default function Page() {
@@ -6,9 +8,64 @@ export default function Page() {
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
-        <section className="py-16 text-center">
-          <h1 className="text-4xl font-bold">Venues</h1>
+        <PageHero
+          title="Run flawless events—from ticket scan to last-call review."
+          subtitle=""
+        />
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <ul className="list-disc pl-5 space-y-2">
+            <li>Integrate with Ticketmaster, Eventbrite, and Shopify in minutes.</li>
+            <li>Queue-busting mobile bars: guests order from seats, pick up when ready.</li>
+            <li>Automated set-time notifications keep crowds flowing and F&B revenue climbing.</li>
+            <li>Post-event surveys feed straight into promoter dashboards to secure re-bookings.</li>
+          </ul>
         </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">End-to-End Event Flow</h2>
+          <table className="min-w-full text-left border-collapse">
+            <thead>
+              <tr>
+                <th className="p-2 border">Stage</th>
+                <th className="p-2 border">EMS Touchpoint</th>
+                <th className="p-2 border">Outcome</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="p-2 border">Ticket purchased</td>
+                <td className="p-2 border">Auto-welcome email with FAQ & cashless wallet link</td>
+                <td className="p-2 border">Fewer “what time do doors open?” calls</td>
+              </tr>
+              <tr>
+                <td className="p-2 border">On arrival</td>
+                <td className="p-2 border">Mobile wallet scan → instant entry</td>
+                <td className="p-2 border">35 % faster gate throughput</td>
+              </tr>
+              <tr>
+                <td className="p-2 border">During show</td>
+                <td className="p-2 border">Push alert: “Bar closed in 15 min—last orders now”</td>
+                <td className="p-2 border">+18 % F&B sales final hour</td>
+              </tr>
+              <tr>
+                <td className="p-2 border">Exit</td>
+                <td className="p-2 border">One-tap survey & merch discount</td>
+                <td className="p-2 border">Higher NPS & incremental revenue</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">Proven Revenue Uplifts</h2>
+          <ul className="list-disc pl-5 space-y-2">
+            <li>+27 % average spend per head when mobile bar ordering is enabled.</li>
+            <li>4.6★ → 4.9★ average review score for venues after 90 days on EMS.</li>
+            <li>12 hours saved weekly by ops teams thanks to automated set-time notifications.</li>
+          </ul>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
+          <p className="text-lg font-semibold">See how EMS turns events into encores →</p>
+        </section>
+        <CTABanner />
         <Footer />
       </main>
     </>

--- a/components/page-hero.tsx
+++ b/components/page-hero.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+
+interface PageHeroProps {
+  title: string;
+  subtitle: string;
+}
+
+const PageHero = ({ title, subtitle }: PageHeroProps) => (
+  <div className="py-20 px-6 bg-accent text-center">
+    <h1 className="text-4xl xs:text-5xl md:text-6xl font-bold max-w-3xl mx-auto tracking-tight">
+      {title}
+    </h1>
+    <p className="mt-6 max-w-2xl mx-auto text-lg text-foreground/80">
+      {subtitle}
+    </p>
+  </div>
+);
+
+export default PageHero;


### PR DESCRIPTION
## Summary
- create `PageHero` component for consistent hero sections
- populate EMS Serve, Send, and Rate pages with detailed marketing copy
- flesh out industry pages for hotels, restaurants, venues, and airbnbs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68664efb11a8832db35e07f7fb5d33f7