### PR TITLE
Add icons and timeline card styles

### DIFF
--- a/app/ems-send/page.tsx
+++ b/app/ems-send/page.tsx
@@ -69,7 +69,7 @@ const reasons = [
 
 const touchpoints = [
   {
-    time: "T – 7 days",
+    time: "7 days before arrival",
     text: "\u201CAdd a late checkout for 20% off.\u201D – Average 14% take-rate",
   },
   {
@@ -85,7 +85,7 @@ const touchpoints = [
     text: "\u201CRate your stay & save 10% on your next booking.\u201D",
   },
   {
-    time: "D + 30",
+    time: "30 days post booking",
     text: "Personalised offer based on spend tier or last-ordered service.",
   },
 ];
@@ -149,9 +149,11 @@ export default function Page() {
           <ol className="relative border-l border-border pl-6 space-y-6">
             {touchpoints.map((item) => (
               <li key={item.time} className="relative">
-                <span className="absolute -left-3 top-1.5 h-2 w-2 rounded-full bg-primary" />
-                <p className="text-sm font-semibold">{item.time}</p>
-                <p className="text-sm text-foreground/80">{item.text}</p>
+                <span className="absolute -left-3 top-4 h-2 w-2 rounded-full bg-primary" />
+                <div className="bg-background border rounded-xl p-4 ml-2">
+                  <p className="text-sm font-semibold">{item.time}</p>
+                  <p className="text-sm text-foreground/80">{item.text}</p>
+                </div>
               </li>
             ))}
           </ol>

--- a/app/ems-serve/page.tsx
+++ b/app/ems-serve/page.tsx
@@ -12,25 +12,33 @@ import {
   Bell,
   CalendarDays,
   ArrowUpRight,
+  Utensils,
+  ConciergeBell,
+  MessageCircle,
+  Info,
 } from "lucide-react";
 
 const guestLove = [
   {
+    icon: Utensils,
     feature: "Digital Ordering",
     examples: "Room-service, poolside F&B, table orders",
     benefit: "Scan, customise, pay in <30 s",
   },
   {
+    icon: ConciergeBell,
     feature: "Service Requests",
     examples: "Extra towels, maintenance, late checkout",
     benefit: "One tap—no phone calls",
   },
   {
+    icon: MessageCircle,
     feature: "Live Chat",
     examples: "Concierge questions, event updates",
     benefit: "Real-time answers, routed to the right team",
   },
   {
+    icon: Info,
     feature: "Info Pages",
     examples: "Hotel guide, local eats, FAQs",
     benefit: "Everything they need in one link",
@@ -111,16 +119,22 @@ export default function Page() {
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Why Guests Love It</h2>
           <div className="grid sm:grid-cols-2 gap-4">
-            {guestLove.map((item) => (
-              <div
-                key={item.feature}
-                className="bg-background border rounded-xl p-5"
-              >
-                <span className="text-lg font-semibold">{item.feature}</span>
-                <p className="text-sm text-foreground/80">{item.examples}</p>
-                <p className="mt-1 text-foreground/80">{item.benefit}</p>
-              </div>
-            ))}
+            {guestLove.map((item) => {
+              const Icon = item.icon;
+              return (
+                <div
+                  key={item.feature}
+                  className="bg-background border rounded-xl p-5 flex flex-col"
+                >
+                  <div className="mb-3 h-10 w-10 flex items-center justify-center bg-muted rounded-full">
+                    <Icon className="h-6 w-6" />
+                  </div>
+                  <span className="text-lg font-semibold">{item.feature}</span>
+                  <p className="text-sm text-foreground/80">{item.examples}</p>
+                  <p className="mt-1 text-foreground/80">{item.benefit}</p>
+                </div>
+              );
+            })}
           </div>
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">


### PR DESCRIPTION
## Summary
- add icons for Why Guests Love It section
- show icons in the cards
- rename two touchpoint headings
- style touchpoint items as cards

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686f81ecec0c832db3ae66681f6417cd