### PR TITLE
Update restaurant page copy and styling

### DIFF
--- a/app/industries/restaurants/page.tsx
+++ b/app/industries/restaurants/page.tsx
@@ -3,36 +3,83 @@ import Footer from "@/components/footer";
 import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
+import { Button } from "@/components/ui/button";
 import {
   QrCode,
-  Ban,
-  Megaphone,
-  AlertTriangle,
-  MapPin,
   Utensils,
-  Check,
-  Gift,
-  Heart,
+  Activity,
+  Repeat,
+  LayoutGrid,
+  Info,
+  Pencil,
+  BarChart2,
+  ArrowUpRight,
+  CalendarDays,
 } from "lucide-react";
 
-const benefits = [
-  { icon: QrCode, title: "QR menus", description: "Table ordering cuts dwell time by 12 minutes." },
-  { icon: Ban, title: "Real-time 86ing", description: "Prevent those awkward 'we\u2019re out' moments." },
-  { icon: Megaphone, title: "Fill slow shifts", description: "Targeted lunch offers drive traffic." },
-  { icon: AlertTriangle, title: "Issue alerts", description: "EMS Rate flags problems before they hit reviews." },
+const challenges = [
+  {
+    challenge: "Slow table turns",
+    fix: "QR table ordering with split-bill & tip options cuts dwell time.",
+  },
+  {
+    challenge: "Menu questions",
+    fix: "Info QRs show allergens, provenance, and chef notes—no staff interruptions.",
+  },
+  {
+    challenge: "Kitchen overload",
+    fix: "Fulfilment screens flag ageing tickets and let chefs pause items in a click.",
+  },
+  {
+    challenge: "Quiet mid-week shifts",
+    fix: "Pre-arrival upsell emails (welcome cocktail, chef’s menu) turn reservations into higher spend.",
+  },
 ];
 
-const workflow = [
-  { icon: MapPin, title: "Seat", description: "Host scans QR to assign table and server." },
-  { icon: Utensils, title: "Order & pay", description: "Guests split bills, tip and reorder without waiting." },
-  { icon: Check, title: "Feedback", description: "Instant 5-second survey before they leave." },
-  { icon: Gift, title: "Retarget", description: "Hyper-local lunch offer hits the next weekday." },
+const journey = [
+  {
+    icon: QrCode,
+    title: "Seat & Scan",
+    description: "Guests scan the table QR, browse, customise, and pay in seconds.",
+  },
+  {
+    icon: Utensils,
+    title: "Serve & Upsell",
+    description: "Smart add-on prompts (“Try truffle fries?”) boost basket size at checkout.",
+  },
+  {
+    icon: Activity,
+    title: "Pulse Feedback",
+    description: "Automated micro-survey drops after dessert; low scores ping the floor manager.",
+  },
+  {
+    icon: Repeat,
+    title: "Retarget & Return",
+    description: "Next-day EMS Send email offers an exclusive weekday lunch deal to fill slow shifts.",
+  },
 ];
 
-const loyalty = [
-  { icon: Heart, title: "Card-free points", description: "Spend logs to a profile; rewards trigger via EMS Send." },
-  { icon: Utensils, title: "Guest DNA", description: "Dietary tags and favourites surface for staff." },
-  { icon: Gift, title: "Win-back", description: "Lapsed guests get offers proven to recapture 23%." },
+const tools = [
+  {
+    icon: LayoutGrid,
+    title: "Live fulfilment boards",
+    description: "Colour-coded timers spotlight orders that need attention.",
+  },
+  {
+    icon: Info,
+    title: "Allergy & Provenance QRs",
+    description: "One tap reveals a full allergen matrix and farm-to-fork stories.",
+  },
+  {
+    icon: Pencil,
+    title: "Instant menu edits",
+    description: "86 an item or update pricing across every QR in under 10 seconds.",
+  },
+  {
+    icon: BarChart2,
+    title: "Revenue dashboards",
+    description: "Track per-cover spend, order flow, and upsell conversion in real time.",
+  },
 ];
 
 export default function Page() {
@@ -41,12 +88,38 @@ export default function Page() {
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
-          title="Seat more diners, turn tables faster, and keep them coming back."
-          subtitle=""
-        />
+          title="Scan. Savour. Spend. Turn every table into a revenue engine—no extra hardware."
+          subtitle="Give guests friction-free ordering, rich storytelling, and irresistible pre-arrival upsells while your team stays in full control."
+        >
+          <Button
+            size="lg"
+            className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+          >
+            Get Started Free <ArrowUpRight className="h-5 w-5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+          >
+            <CalendarDays className="h-5 w-5" /> Book a Demo
+          </Button>
+        </PageHero>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
+          <h2 className="text-2xl font-semibold">Why Operators Love EMS</h2>
+          <div className="grid md:grid-cols-2 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+            {challenges.map((row) => (
+              <div key={row.challenge} className="border p-6 -mt-px -ml-px">
+                <div className="font-semibold">{row.challenge}</div>
+                <p className="mt-2 text-sm xs:text-base">{row.fix}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
+          <h2 className="text-2xl font-semibold">“Seat-to-Repeat” Guest Journey</h2>
           <div className="grid sm:grid-cols-2 gap-4">
-            {benefits.map((item) => (
+            {journey.map((item) => (
               <FeatureCard
                 key={item.title}
                 icon={item.icon}
@@ -55,25 +128,11 @@ export default function Page() {
               />
             ))}
           </div>
-          <p className="font-semibold">Restaurants using EMS cut walk-outs by 18 % and grow per-cover spend by 22 % in the first quarter.</p>
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">From Seat to Repeat – Workflow</h2>
+          <h2 className="text-2xl font-semibold">Tools That Delight Guests and Staff</h2>
           <div className="grid sm:grid-cols-2 gap-4">
-            {workflow.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
-          </div>
-        </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Loyalty & CRM Booster</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {loyalty.map((item) => (
+            {tools.map((item) => (
               <FeatureCard
                 key={item.title}
                 icon={item.icon}
@@ -84,7 +143,8 @@ export default function Page() {
           </div>
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
-          <p className="text-lg font-semibold">Book a tasting tour of EMS for restaurants →</p>
+          <p className="text-lg font-semibold">“Guests love the control, staff love the calm—and we bank the upsells.”</p>
+          <p className="mt-2">— Operations Director, Warwickshire Bistro</p>
         </section>
         <CTABanner />
         <Footer />


### PR DESCRIPTION
## Summary
- restyle restaurant page hero with CTAs
- add operator challenge table
- detail Seat‑to‑Repeat guest journey
- list new tools for guests and staff

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878c09dfd1c832da03d11ad692057ec