### PR TITLE
Update hotel page pick & mix layout

### DIFF
--- a/app/industries/hotels/page.tsx
+++ b/app/industries/hotels/page.tsx
@@ -131,16 +131,40 @@ export default function Page() {
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">“Pick & Mix” Your Perfect Guest Journey</h2>
-          <div className="flex flex-wrap justify-center gap-4">
+          {/* Mobile/Tablet layout */}
+          <div className="flex flex-wrap justify-center gap-4 md:hidden">
             {modules.map((item) => (
               <FeatureCard
                 key={item.title}
                 icon={item.icon}
                 title={item.title}
                 description={item.description}
-                className="w-full sm:w-1/2 md:w-1/3"
+                className="w-full sm:w-1/2"
               />
             ))}
+          </div>
+          {/* Desktop layout: 3 cards then 2 cards */}
+          <div className="hidden md:block">
+            <div className="grid grid-cols-3 gap-4">
+              {modules.slice(0, 3).map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
+            <div className="grid grid-cols-2 gap-4 mt-4">
+              {modules.slice(3).map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
           </div>
           <p>Activate only the modules you need today; add more anytime with one click.</p>
         </section>


### PR DESCRIPTION
## Summary
- tweak hotel page module layout to show 3 cards on the first row and 2 cards on the second row on desktop

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878c2af742c832d96dd1d7257f6f8b5