### PR TITLE
Style Venues Journey section like EMS Send timeline

### DIFF
--- a/app/industries/venues/page.tsx
+++ b/app/industries/venues/page.tsx
@@ -101,14 +101,17 @@ export default function Page() {
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
           <h2 className="text-2xl font-semibold">“Door-to-Encore” Journey</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-3 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+          <ol className="relative border-l border-border pl-6 space-y-6">
             {journey.map((row) => (
-              <div key={row.stage} className="border p-6 -mt-px -ml-px">
-                <div className="font-semibold">{row.stage}</div>
-                <p className="mt-2 text-sm xs:text-base">{row.exp}</p>
-              </div>
+              <li key={row.stage} className="relative">
+                <span className="absolute -left-3 top-4 h-2 w-2 rounded-full bg-primary" />
+                <div className="bg-background border rounded-xl p-4 ml-2">
+                  <p className="text-sm font-semibold">{row.stage}</p>
+                  <p className="text-sm text-foreground/80">{row.exp}</p>
+                </div>
+              </li>
             ))}
-          </div>
+          </ol>
         </section>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
           <h2 className="text-2xl font-semibold">Tools That Keep Crowds Happy and Ops Calm</h2>


### PR DESCRIPTION
## Summary
- restyle the "Door-to-Encore" Journey on the venues page using timeline formatting

## Testing
- `npm run lint` *(fails: UtensilsCrossed defined but never used)*
- `npm run build` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7a41b90832db3930d1d99fe564a