### PR TITLE
Style about page and fix quotes

### DIFF
--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -1,6 +1,9 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
+import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
+import { Button } from "@/components/ui/button";
+import { ArrowUpRight, CalendarDays } from "lucide-react";
 
 export default function Page() {
   return (
@@ -9,8 +12,22 @@ export default function Page() {
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
           title="The Team Behind EMS"
-          subtitle="\u201CEvery guest. Every touchpoint. Elevated.\u201D We build pick-and-mix tech that helps hotels, restaurants, venues, clinics, and short-stay hosts turn routine interactions into unforgettable (and profitable) moments."
-        />
+          subtitle="“Every guest. Every touchpoint. Elevated.” We build pick-and-mix tech that helps hotels, restaurants, venues, clinics, and short-stay hosts turn routine interactions into unforgettable (and profitable) moments."
+        >
+          <Button
+            size="lg"
+            className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+          >
+            Get Started Free <ArrowUpRight className="h-5 w-5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="lg"
+            className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+          >
+            <CalendarDays className="h-5 w-5" /> Book a Demo
+          </Button>
+        </PageHero>
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Our Story</h2>
           <p>
@@ -80,6 +97,8 @@ export default function Page() {
           <p>Ready to swap clipboard chaos for connected guests and new profit lines?</p>
           <p>Let’s enhance every guest experience—together.</p>
         </section>
+
+        <CTABanner />
 
         <Footer />
       </main>

--- a/app/ems-rate/page.tsx
+++ b/app/ems-rate/page.tsx
@@ -43,7 +43,7 @@ const reasons = [
     icon: Brain,
     title: "AI sentiment & predictive alerts",
     description:
-      "Dashboards highlight emerging themes (\u201Cslow breakfast\u201D, \u201Cspotless rooms\u201D) and flag score dips before they snowball.",
+      "Dashboards highlight emerging themes (“slow breakfast”, “spotless rooms”) and flag score dips before they snowball.",
   },
 ];
 

--- a/app/ems-send/page.tsx
+++ b/app/ems-send/page.tsx
@@ -70,11 +70,11 @@ const reasons = [
 const touchpoints = [
   {
     time: "7 days before arrival",
-    text: "\u201CAdd a late checkout for 20% off.\u201D – Average 14% take-rate",
+    text: "“Add a late checkout for 20% off.” – Average 14% take-rate",
   },
   {
     time: "Check-in morning",
-    text: "\u201CFancy a welcome cocktail? Order now, skip the queue.\u201D",
+    text: "“Fancy a welcome cocktail? Order now, skip the queue.”",
   },
   {
     time: "Mid-stay",
@@ -82,7 +82,7 @@ const touchpoints = [
   },
   {
     time: "Checkout +1 hour",
-    text: "\u201CRate your stay & save 10% on your next booking.\u201D",
+    text: "“Rate your stay & save 10% on your next booking.”",
   },
   {
     time: "30 days post booking",


### PR DESCRIPTION
## Summary
- add CTABanner and hero actions on the About page
- replace escaped unicode quotes with real characters in several pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878d036613c832d932b7b0f8a62ea13