### PR TITLE
Refine landing page messaging

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,7 @@ import "./globals.css";
 export const metadata: Metadata = {
   title: "PureLanding - Beautiful Shadcn UI Landing Page",
   description:
-    "A beautiful landing page built with Shadcn UI, Next.js 15, Tailwind CSS, and Shadcn UI Blocks.",
+    "Enhance My Stay | Automate upsell emails pre-, in-, and post-stay, embed your custom-branded upsell store link, and streamline guest guides - no extra apps, just more revenue and happier guests.",
   keywords: [
     "PureLanding",
     "PureLanding Landing Page",
@@ -29,7 +29,7 @@ export const metadata: Metadata = {
     url: "https://shadcn-landing-page.vercel.app",
     title: "PureLanding - Beautiful Shadcn UI Landing Page",
     description:
-      "A beautiful landing page built with Shadcn UI, Next.js 15, Tailwind CSS, and Shadcn UI Blocks.",
+      "Enhance My Stay | Automate upsell emails pre-, in-, and post-stay, embed your custom-branded upsell store link, and streamline guest guides - no extra apps, just more revenue and happier guests.",
     images: [
       {
         url: "/og-image.jpg",

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -7,11 +7,10 @@ const Hero = () => {
     <div className="min-h-[calc(100vh-6rem)] flex flex-col md:flex-row items-center justify-between gap-8 py-20 px-10 bg-accent">
       <div className="md:w-1/2 text-center md:text-left max-w-2xl">
         <h1 className="max-w-[20ch] mt-6 text-3xl xs:text-4xl sm:text-5xl md:text-6xl font-bold !leading-[1.1] tracking-tight">
-          Ordering, Requests, Reviews
-          <br className="hidden md:block" /> <span style={{ color: "#F65053" }}>Reimagined</span>
+          Automated Upsells & Guest Engagement
         </h1>
         <p className="mt-6 max-w-[60ch] xs:text-lg">
-          EMS brings ordering, requests, live chat, and real-time feedback together—no clunky apps, no friction. Just faster service, more upsells, and happier guests.
+          Automatically email guests before, during, and after their booking - or embed a link into your existing messages - to drive revenue and elevate the guest experience.
         </p>
         <div className="mt-12 flex flex-col sm:flex-row items-center sm:justify-start md:justify-start gap-4">
           <Button size="lg" className="w-full sm:w-auto rounded-full text-base">


### PR DESCRIPTION
## Summary
- Update global meta description and OpenGraph metadata to emphasize automated upsells and guest guides.
- Refresh hero heading and subheading to promote automated guest engagement.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a4f90110832dba85fa5e2bdfe15c