### PR TITLE
feat(hero): override Lottie aspect ratio

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -46,6 +46,7 @@ const Hero = () => {
             animationData={heroAnimation}
             loop
             className="w-full h-full object-fill rounded-3xl"
+            rendererSettings={{ preserveAspectRatio: "xMidYMid slice" }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure hero Lottie animation fills its frame by setting `preserveAspectRatio: 'xMidYMid slice'`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890dca562c4832da9d35f4d58b1574c