### PR TITLE
Use contain aspect ratio for hero animation

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -45,8 +45,8 @@ const Hero = () => {
           <Lottie
             animationData={heroAnimation}
             loop
-            className="w-full h-full object-fill rounded-3xl"
-            rendererSettings={{ preserveAspectRatio: "xMidYMid slice" }}
+            className="w-full h-full object-contain rounded-3xl"
+            rendererSettings={{ preserveAspectRatio: "xMidYMid meet" }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- ensure hero animation keeps full aspect ratio by using `object-contain`
- use `preserveAspectRatio: "xMidYMid meet"` in Lottie renderer settings

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890f4ddbfb4832d891b4d1c078249c9