### PR TITLE
feat: replace landing page testimonials

### DIFF
--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -7,58 +7,170 @@ import React, { ComponentProps } from "react";
 const testimonials = [
   {
     id: 1,
-    name: "Manager",
-    designation: "Boutique Hotel, Brighton",
+    name: "GM",
+    designation: "74-room boutique hotel, Bath",
     testimonial:
-      "Guests actually used it. Orders doubled in the first weekend. Our team didn’t need a single training session.",
+      "Pre-arrival emails now do the selling for us. Upgrades, parking, late checkout—+17% ancillary within a month.",
     avatar: "",
   },
   {
     id: 2,
-    name: "Owner",
-    designation: "Countryside B&B, Yorkshire",
+    name: "Front Office Manager",
+    designation: "city hotel, Glasgow",
     testimonial:
-      "Finally a tool that does what it says. We cut response times by half and started taking upsell bookings before guests even arrived.",
+      "The welcome email killed the 'where do I park?' calls. Guests arrive calmer—and upsell take-rate hit 12%.",
     avatar: "",
   },
   {
     id: 3,
-    name: "Ops Lead",
-    designation: "Mid-size Hotel Chain, Manchester",
+    name: "Spa Director",
+    designation: "resort hotel, Cornwall",
     testimonial:
-      "We’ve tried four different platforms. EMS is the first one staff like using. And it doesn’t scare off guests.",
+      "Mid-stay tips + spa offer = weeknight spa bookings up 22%. All from one automated flow.",
     avatar: "",
   },
   {
     id: 4,
-    name: "Hotel GM",
-    designation: "London",
+    name: "Marketing Lead",
+    designation: "heritage hotel, York",
     testimonial:
-      "Our biggest win? No more missed requests. That alone has saved us a ton of comped drinks and apologies.",
+      "Local recs in the day-before email get 60% click-through. Guests feel looked after before they even check in.",
     avatar: "",
   },
   {
     id: 5,
-    name: "Event Venue Director",
-    designation: "Bristol",
+    name: "Revenue Manager",
+    designation: "airport hotel, Manchester",
     testimonial:
-      "We plugged in EMS for a weekend festival. Guests ordered food, asked questions, left reviews — all without us needing extra staff.",
+      "We added late checkout to the T-24h email and it prints money. +£9.80 per booking on average.",
     avatar: "",
   },
   {
     id: 6,
-    name: "Hotel Receptionist",
-    designation: "Glasgow",
+    name: "Owner",
+    designation: "coastal inn, Dorset",
     testimonial:
-      "Live chat is a game-changer. Guests ask, we respond instantly, and our front desk isn’t swamped.",
+      "Post-stay thank-you + direct rebook code: repeat stays up 14% without lifting a finger.",
     avatar: "",
   },
   {
     id: 7,
-    name: "Guest Experience Manager",
-    designation: "Seaside Resort",
+    name: "GM",
+    designation: "business hotel, Birmingham",
     testimonial:
-      "We were flying blind before. Now we know what guests are asking for while they’re still here. That’s powerful.",
+      "No fancy integrations—just a CSV and great timing. We launched in a day and it paid back in a week.",
+    avatar: "",
+  },
+  {
+    id: 8,
+    name: "Ops Manager",
+    designation: "countryside hotel, Cotswolds",
+    testimonial:
+      "Guests love the tone; ops loves the quiet inbox. The guide email cut questions by half.",
+    avatar: "",
+  },
+  {
+    id: 9,
+    name: "Owner-Operator",
+    designation: "brasserie, Bristol",
+    testimonial:
+      "Pre-booking email with a welcome cocktail? 18% of diners pre-add it. Easy win.",
+    avatar: "",
+  },
+  {
+    id: 10,
+    name: "GM",
+    designation: "modern European, Leeds",
+    testimonial:
+      "Chef's menu 'pre-order only' in the confirmation email sells out weekends. Higher spend, smoother service.",
+    avatar: "",
+  },
+  {
+    id: 11,
+    name: "Group Manager",
+    designation: "neighbourhood dining, London",
+    testimonial:
+      "Day-of reminder with local parking tips + add a dessert board—+11% ticket on a Tuesday.",
+    avatar: "",
+  },
+  {
+    id: 12,
+    name: "Co-Founder",
+    designation: "wine bar & kitchen, Edinburgh",
+    testimonial:
+      "Post-meal note with neighbourhood recs keeps us top of mind. Return bookings climbed 9%.",
+    avatar: "",
+  },
+  {
+    id: 13,
+    name: "Marketing Lead",
+    designation: "casual dining group, Cardiff",
+    testimonial:
+      "We swapped generic newsletters for timed flows around bookings. Open rates doubled; basket size followed.",
+    avatar: "",
+  },
+  {
+    id: 14,
+    name: "Commercial Manager",
+    designation: "2k-cap venue, Liverpool",
+    testimonial:
+      "Pre-event email upsells drink tokens and VIP entry—per-head spend up 15% before doors open.",
+    avatar: "",
+  },
+  {
+    id: 15,
+    name: "F&B Lead",
+    designation: "theatre, Newcastle",
+    testimonial:
+      "Set-time mail with 'skip the queue—pre-order now' is a license to print money.",
+    avatar: "",
+  },
+  {
+    id: 16,
+    name: "Ops Director",
+    designation: "arena, Midlands",
+    testimonial:
+      "Missed-the-merch follow-up the next morning clears stock without discounting.",
+    avatar: "",
+  },
+  {
+    id: 17,
+    name: "Event Manager",
+    designation: "concert hall, Dublin",
+    testimonial:
+      "Local travel and timings in the welcome note slashed 'what time?' messages. Team finally breathes.",
+    avatar: "",
+  },
+  {
+    id: 18,
+    name: "Director",
+    designation: "holiday lets, North Devon",
+    testimonial:
+      "Pre-arrival email offers early check-in/firewood hamper. +£7.30 per stay across 42 cottages.",
+    avatar: "",
+  },
+  {
+    id: 19,
+    name: "Superhost",
+    designation: "12 units, Brighton",
+    testimonial:
+      "Mid-stay local recs stopped the 'what should we do?' messages—and lifted late-checkout buys by 13%.",
+    avatar: "",
+  },
+  {
+    id: 20,
+    name: "Portfolio Manager",
+    designation: "60 units, Lake District",
+    testimonial:
+      "Post-stay thank-you + direct rebook link = repeat direct up 16%. OTA fees down, stress down.",
+    avatar: "",
+  },
+  {
+    id: 21,
+    name: "Owner",
+    designation: "serviced apartments, Belfast",
+    testimonial:
+      "We just upload bookings. The flows do the rest. Zero faff, real money.",
     avatar: "",
   },
 ];


### PR DESCRIPTION
## Summary
- replace landing page testimonials with new quotes spanning hotels, dining, events, and rentals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da20e16b4832da4607f2f07a5a031