### PR TITLE
feat: wrap pricing section in card

### DIFF
--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -1,45 +1,49 @@
 "use client";
 
+import { Card } from "@/components/ui/card";
+
 export default function Pricing() {
   return (
     <div id="pricing" className="flex flex-col items-center justify-center py-12 xs:py-20 px-6">
-      <h1 className="text-3xl xs:text-4xl md:text-5xl font-bold text-center tracking-tight">
-        Simple pricing. One clear price.
-      </h1>
-      <p className="mt-4 max-w-[60ch] xs:text-lg text-center">
-        Everything you need to unlock pre-arrival upsells, guest guides and fulfilment.
-      </p>
-      <div className="mt-8 flex items-baseline justify-center gap-2">
-        <span className="text-5xl font-bold">£40</span>
-        <span className="text-lg font-semibold">/ property / month + VAT</span>
-      </div>
-      <div className="mt-8 max-w-screen-md mx-auto">
-        <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
-        <ul className="mt-4 space-y-2 text-sm md:text-base">
-          <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
-          <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
-          <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
-          <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
-          <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
-          <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
-          <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
-          <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
-          <li>✅ Multi-property management — Manage properties from one account.</li>
-          <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
-          <li>✅ 14-day free trial included</li>
-        </ul>
-      </div>
-      <div className="mt-8 max-w-screen-md mx-auto">
-        <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
-        <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
-          <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
-          <li>All plans charged + VAT.</li>
-          <li>Extra properties enjoy a 25% discount</li>
-        </ul>
-      </div>
-      <p className="mt-8 text-center text-sm text-muted-foreground max-w-[80ch]">
-        Need volume pricing or enterprise terms? Contact us - we offer custom discounts for larger portfolios and dedicated support packages.
-      </p>
+      <Card className="w-full max-w-screen-md p-8">
+        <h1 className="text-3xl xs:text-4xl md:text-5xl font-bold text-center tracking-tight">
+          Simple pricing. One clear price.
+        </h1>
+        <p className="mt-4 max-w-[60ch] xs:text-lg text-center">
+          Everything you need to unlock pre-arrival upsells, guest guides and fulfilment.
+        </p>
+        <div className="mt-8 flex items-baseline justify-center gap-2">
+          <span className="text-5xl font-bold">£40</span>
+          <span className="text-lg font-semibold">/ property / month + VAT</span>
+        </div>
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
+          <ul className="mt-4 space-y-2 text-sm md:text-base">
+            <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
+            <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
+            <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
+            <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
+            <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
+            <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
+            <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
+            <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
+            <li>✅ Multi-property management — Manage properties from one account.</li>
+            <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
+            <li>✅ 14-day free trial included</li>
+          </ul>
+        </div>
+        <div className="mt-8">
+          <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
+          <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
+            <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
+            <li>All plans charged + VAT.</li>
+            <li>Extra properties enjoy a 25% discount</li>
+          </ul>
+        </div>
+        <p className="mt-8 text-center text-sm text-muted-foreground max-w-[80ch]">
+          Need volume pricing or enterprise terms? Contact us - we offer custom discounts for larger portfolios and dedicated support packages.
+        </p>
+      </Card>
     </div>
   );
 }

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("rounded-xl border bg-card text-card-foreground shadow", className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex flex-col space-y-1.5 p-6", className)}
+      {...props}
+    />
+  )
+);
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3
+      ref={ref}
+      className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+      {...props}
+    />
+  )
+);
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p
+      ref={ref}
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("p-6 pt-0", className)}
+      {...props}
+    />
+  )
+);
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("flex items-center p-6 pt-0", className)}
+      {...props}
+    />
+  )
+);
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+


### PR DESCRIPTION
## Summary
- add reusable Card component for consistent card styling
- render pricing information inside a centered Card

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689da3caf0f8832da66e43399f73b878