### PR TITLE
Improve testimonials speed, CTA background, and pricing card

### DIFF
--- a/components/cta-banner.tsx
+++ b/components/cta-banner.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 export default function CTABanner() {
   return (
     <div className="px-6">
-      <div className="relative overflow-hidden my-20 w-full bg-background text-foreground max-w-screen-lg mx-auto rounded-2xl py-10 md:py-16 px-6 md:px-14">
+      <div className="relative overflow-hidden my-20 w-full bg-black text-white max-w-screen-lg mx-auto rounded-2xl py-10 md:py-16 px-6 md:px-14">
         <AnimatedGridPattern
           numSquares={30}
           maxOpacity={0.1}

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -9,33 +9,37 @@ export default function Pricing() {
       <p className="mt-4 max-w-[60ch] xs:text-lg text-center">
         Everything you need to unlock pre-arrival upsells, guest guides and fulfilment.
       </p>
-      <div className="mt-8 flex items-baseline justify-center gap-2">
-        <span className="text-5xl font-bold">£40</span>
-        <span className="text-lg font-semibold">/ property / month + VAT</span>
-      </div>
-      <div className="mt-8 max-w-screen-md mx-auto">
-        <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
-        <ul className="mt-4 space-y-2 text-sm md:text-base">
-          <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
-          <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
-          <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
-          <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
-          <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
-          <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
-          <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
-          <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
-          <li>✅ Multi-property management — Manage properties from one account.</li>
-          <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
-          <li>✅ 14-day free trial included</li>
-        </ul>
-      </div>
-      <div className="mt-8 max-w-screen-md mx-auto">
-        <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
-        <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
-          <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
-          <li>All plans charged + VAT.</li>
-          <li>Extra properties enjoy a 25% discount</li>
-        </ul>
+      <div className="mt-8 w-full max-w-screen-md">
+        <div className="bg-accent rounded-2xl p-8 shadow flex flex-col items-center">
+          <div className="flex items-baseline justify-center gap-2">
+            <span className="text-5xl font-bold">£59</span>
+            <span className="text-lg font-semibold">/ property / month + VAT</span>
+          </div>
+          <div className="mt-8 w-full">
+            <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
+            <ul className="mt-4 space-y-2 text-sm md:text-base">
+              <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
+              <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
+              <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
+              <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
+              <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
+              <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
+              <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
+              <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
+              <li>✅ Multi-property management — Manage properties from one account.</li>
+              <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
+              <li>✅ 14-day free trial included</li>
+            </ul>
+          </div>
+          <div className="mt-8 w-full">
+            <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
+            <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
+              <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
+              <li>All plans charged + VAT.</li>
+              <li>Extra properties enjoy a 25% discount</li>
+            </ul>
+          </div>
+        </div>
       </div>
       <p className="mt-8 text-center text-sm text-muted-foreground max-w-[80ch]">
         Need volume pricing or enterprise terms? Contact us - we offer custom discounts for larger portfolios and dedicated support packages.

--- a/components/testimonials.tsx
+++ b/components/testimonials.tsx
@@ -184,10 +184,10 @@ const Testimonials = () => (
       <div className="relative">
         <div className="z-10 absolute left-0 inset-y-0 w-[15%] bg-gradient-to-r from-background to-transparent" />
         <div className="z-10 absolute right-0 inset-y-0 w-[15%] bg-gradient-to-l from-background to-transparent" />
-        <Marquee pauseOnHover className="[--duration:20s]">
+        <Marquee pauseOnHover className="[--duration:120s]">
           <TestimonialList />
         </Marquee>
-        <Marquee pauseOnHover reverse className="mt-0 [--duration:20s]">
+        <Marquee pauseOnHover reverse className="mt-0 [--duration:120s]">
           <TestimonialList />
         </Marquee>
       </div>


### PR DESCRIPTION
## Summary
- Slow testimonial marquee for smoother movement
- Restore black background behind CTA banner
- Style pricing section with card and update rate to £59 per property per month

## Testing
- `npm run lint`
- `npm run build` *(fails: creating an optimized production build ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aed50b2360832da364f3bf62a444f3