### PR TITLE
Revise industry and about pages

### DIFF
--- a/app/about-us/page.tsx
+++ b/app/about-us/page.tsx
@@ -1,6 +1,5 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
-import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { ArrowUpRight, CalendarDays } from "lucide-react";
@@ -12,7 +11,7 @@ export default function Page() {
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
           title="The Team Behind EMS"
-          subtitle="“Every guest. Every touchpoint. Elevated.” We build pick-and-mix tech that helps hotels, restaurants, venues, clinics, and short-stay hosts turn routine interactions into unforgettable (and profitable) moments."
+          subtitle="“Every guest. Every touchpoint. Elevated.”"
         >
           <Button
             size="lg"
@@ -28,78 +27,65 @@ export default function Page() {
             <CalendarDays className="h-5 w-5" /> Book a Demo
           </Button>
         </PageHero>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Our Story</h2>
+          <p>It started with one question:</p>
+          <p>Why do guests wade through noise when a simple email could do the work?</p>
           <p>
-            Back in 2019 we asked a simple question: Why are guests spending
-            hours dealing with information overload while their phones can do
-            everything?
+            In 2019 we built an AI engine to personalise hotel bookings. It worked—guests were happier, revenue went up. Hotels then asked: “Can you help us sell more before guests arrive?” We listened.
           </p>
           <p>
-            We started by crunching OTA data with a home-grown AI engine that
-            matched travellers to the perfect room. It worked—bookings rose,
-            guests smiled.
-          </p>
-          <p>
-            Then hotels told us, “Great, but can you also help us sell fizz,
-            late checkout, and spa slots before they arrive?” Challenge
-            accepted.
-          </p>
-          <p>
-            We pivoted, packed our brains into EMS—a pick-and-mix platform that
-            fires personalised upsells, QR ordering, and real-time feedback
-            without the headache of heavy integrations.
-          </p>
-          <p>
-            Hoteliers loved it. Then restaurateurs asked for table-ordering,
-            arenas wanted seat-delivery, and Airbnb hosts begged for hands-free
-            review capture. Challenge accepted.
-          </p>
-          <p>
-            Today EMS is a modular platform—QR journeys, pre-arrival emails,
-            live chat, instant surveys—ready to bolt onto any experience you
-            offer, from gala dinners to day surgeries and more!
+            EMS was born: an automation engine built for hospitality. From there, restaurants, venues, and Airbnbs joined in. The idea stayed the same—replace messy manual work with seamless, branded communications that guests love.
           </p>
         </section>
 
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">What Drives Us</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li>Level the field – Give independents the same power as multinationals.</li>
-            <li>Keep it human – Let staff focus on smiles while the platform handles the clicks.</li>
-            <li>Ship fast – Frequent updates, daily feedback loops, zero tech jargon.</li>
+            <li>Level the field — Give independents the same power as global chains.</li>
+            <li>Keep it human — Staff focus on service, EMS handles the clicks.</li>
+            <li>Ship fast — No jargon, no long integrations—just quick wins.</li>
           </ul>
         </section>
 
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Mission</h2>
-          <p>Democratise guest-experience tech.</p>
+          <p>To democratise guest-experience tech.</p>
           <p>
-            If you can print a QR code, you can launch EMS. No dev team, no
-            six-month rollout—just plug-and-play tools that add spend, slash
-            queues, and turn guests into superfans.
+            If you can upload a CSV, you can run EMS. No dev team, no six-month rollout. Just plug-and-play tools that boost revenue, save staff time, and turn guests into repeat fans.
           </p>
         </section>
 
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Who We Serve</h2>
           <ul className="list-disc pl-6 space-y-2">
-            <li>Boutique &amp; chain hotels chasing ancillary revenue.</li>
-            <li>Restaurants &amp; cafés turning tables faster without pressure.</li>
-            <li>Stadiums, theatres &amp; festivals keeping crowds flowing (and spending).</li>
-            <li>Airbnb hosts &amp; property managers earning more, sleeping better.</li>
-            <li>Private clinics &amp; spas upgrading patient care with concierge-style add-ons.</li>
+            <li>Hotels chasing ancillary revenue.</li>
+            <li>Restaurants driving midweek demand.</li>
+            <li>Venues lifting per-head spend.</li>
+            <li>Short-stay hosts boosting reviews and rebookings.</li>
           </ul>
         </section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4 text-center">
-          <h2 className="text-2xl font-semibold">Join Us</h2>
-          <p>Ready to swap clipboard chaos for connected guests and new profit lines?</p>
-          <p>Let’s enhance every guest experience—together.</p>
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+          <p>Drop the clunky workflows. EMS brings automations, guides, and upsells into one streamlined system.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+            <Button
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+            >
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+            >
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Button>
+          </div>
         </section>
-
-        <CTABanner />
-
         <Footer />
       </main>
     </>

--- a/app/industries/airbnbs/page.tsx
+++ b/app/industries/airbnbs/page.tsx
@@ -1,104 +1,88 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
-import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
-  MailOpen,
-  QrCode,
-  LayoutGrid,
-  BarChartBig,
   ArrowUpRight,
-  CalendarDays
+  CalendarDays,
+  Mail,
+  Calendar,
+  TrendingUp,
+  Users,
 } from "lucide-react";
-
-
 
 const challenges = [
   {
-    challenge: "Guests ask the same questions",
-    fix:
-      "Info QRs link to digital house guides, Wi-Fi codes, local tips—no inbox ping-pong.",
+    challenge: "Guests asking the same questions",
+    fix: "Automated welcome emails with house guides, Wi-Fi codes, check-in details, and local tips.",
   },
   {
-    challenge: "Leaving money on the table",
-    fix:
-      "Pre-arrival upsell emails (early check-in, welcome hamper, firewood pack) convert before guests arrive.",
+    challenge: "Missed add-on opportunities",
+    fix: "Pre-arrival emails upsell early check-in, welcome hampers, firewood packs, or bike rentals.",
   },
   {
-    challenge: "After-hours messages",
-    fix: "One-tap service requests route issues to on-call or maintenance instantly.",
-  },
-  {
-    challenge: "Ratings make or break revenue",
-    fix: "EMS Rate prompts verified reviews and flags problems privately.",
+    challenge: "Rating pressure",
+    fix: "Post-stay thank-you emails capture reviews and encourage direct rebooking.",
   },
 ];
 
 const journey = [
   {
-    moment: "Booking confirmed",
-    touch: "Thank-you email + optional paid add-ons",
-    value: "New revenue before arrival",
+    stage: "Booking Confirmed",
+    description: "Personalised email + upsell add-ons.",
   },
   {
-    moment: "T-3 days",
-    touch: "Reminder email upsells early check-in or late checkout",
-    value: "Increases spend & staggered arrivals",
+    stage: "T-3 Days",
+    description: "Reminder email with extras and recommendations.",
   },
   {
-    moment: "Arrival",
-    touch: "QR welcome card opens guidebook & service request menu",
-    value: "Fewer calls, happier guests",
+    stage: "Arrival Day",
+    description: "Welcome email with property info and local guide links.",
   },
   {
-    moment: "Mid-stay",
-    touch: "Quick micro-survey + local experience offer",
-    value: "Real-time issue capture & upsell",
+    stage: "Mid-Stay",
+    description: "Optional targeted email with experience offers.",
   },
   {
-    moment: "Checkout",
-    touch: "Capture review & rebook discount",
-    value: "Higher star rating, direct repeat stays",
+    stage: "Checkout",
+    description: "Thank-you + review prompt + rebook discount.",
   },
 ];
 
 const tools = [
   {
-    icon: MailOpen,
-    title: "Pre-Arrival EMS Send",
-    description:
-      "Drag-and-drop emails timed to each stay; upsell extras in a click.",
+    icon: Users,
+    title: "Fulfilment dashboards",
+    description: "Track who booked what and whether it’s been delivered.",
   },
   {
-    icon: QrCode,
-    title: "In-House QRs",
-    description:
-      "Digital guidebooks, firewood orders, linen swaps—everything in guests’ pockets.",
+    icon: Calendar,
+    title: "Calendar-linked products",
+    description: "Sell assets like parking spots or equipment rentals without clashes.",
   },
   {
-    icon: LayoutGrid,
-    title: "Live Fulfilment Board",
-    description:
-      "See open requests, who’s on it, and SLA timers at a glance.",
+    icon: TrendingUp,
+    title: "Revenue insights",
+    description: "See what products convert and where to improve.",
   },
   {
-    icon: BarChartBig,
-    title: "Revenue Dashboards",
-    description:
-      "Track add-on sales and review scores per property or portfolio.",
+    icon: Mail,
+    title: "CSV/PMS sync",
+    description: "Upload bookings from a spreadsheet or connect your PMS.",
   },
 ];
+
 export default function Page() {
   return (
     <>
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
-          title="Turn every booking into a bigger payout."
-          subtitle="From one spare room to 500+ units, EMS lets hosts and property managers upsell extras, answer questions with QR codes, and collect rave reviews on autopilot."
->
+          title="Turn Every Booking Into a Bigger Payout"
+          subtitle="Whether you run one spare room or hundreds of units, EMS automates pre-arrival communication, upsells extras, and captures reviews without you lifting a finger."
+        >
           <Button
             size="lg"
             className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
@@ -113,34 +97,33 @@ export default function Page() {
             <CalendarDays className="h-5 w-5" /> Book a Demo
           </Button>
         </PageHero>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Why Hosts & Managers Choose EMS</h2>
-          <div className="grid md:grid-cols-2 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+          <h2 className="text-2xl font-semibold">Why Hosts &amp; Managers Choose EMS</h2>
+          <div className="grid md:grid-cols-2 gap-4">
             {challenges.map((row) => (
-              <div key={row.challenge} className="border p-6 -mt-px -ml-px space-y-1">
+              <Card key={row.challenge} className="p-6 space-y-1">
                 <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
                 <p className="font-semibold">{row.challenge}</p>
                 <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
                 <p className="text-sm">{row.fix}</p>
-              </div>
+              </Card>
             ))}
           </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">“Booking-to-Rebooking” Guest Journey</h2>
-          <ol className="relative border-l border-border pl-6 space-y-6">
-            {journey.map((row) => (
-              <li key={row.moment} className="relative">
-                <span className="absolute -left-3 top-4 h-2 w-2 rounded-full bg-primary" />
-                <div className="bg-background border rounded-xl p-4 ml-2">
-                  <p className="text-sm font-semibold">{row.moment}</p>
-                  <p className="text-sm text-foreground/80">{row.touch}</p>
-                  <p className="text-sm text-foreground/80">{row.value}</p>
-                </div>
-              </li>
+          <h2 className="text-2xl font-semibold">Booking-to-Rebooking Guest Journey</h2>
+          <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-4">
+            {journey.map((item) => (
+              <Card key={item.stage} className="p-6 text-center space-y-2">
+                <p className="text-lg font-semibold">{item.stage}</p>
+                <p className="text-sm text-foreground/80">{item.description}</p>
+              </Card>
             ))}
-          </ol>
+          </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
           <h2 className="text-2xl font-semibold">Tools That Keep Hosts Happy</h2>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -154,11 +137,33 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
-          <p className="text-lg font-semibold">“EMS turned guest questions into self-serve clicks and upsells I never thought to offer.”</p>
-          <p className="mt-2">— Anna Doyle, Superhost & Portfolio Manager</p>
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <p className="text-lg font-semibold">
+            “EMS turned endless questions into smooth self-service—and new revenue streams we never thought to try.”
+          </p>
+          <p>— Anna Doyle, Superhost</p>
         </section>
-        <CTABanner />
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+          <p>Get more revenue and fewer headaches—without hiring more staff.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+            <Button
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+            >
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+            >
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Button>
+          </div>
+        </section>
         <Footer />
       </main>
     </>

--- a/app/industries/hotels/page.tsx
+++ b/app/industries/hotels/page.tsx
@@ -1,90 +1,78 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
-import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
   ArrowUpRight,
   CalendarDays,
-  Utensils,
-  ConciergeBell,
-  Info,
-  MessageCircle,
-  LayoutGrid,
-  Shuffle,
-  BarChart2,
+  Mail,
+  Calendar,
+  TrendingUp,
+  Users,
 } from "lucide-react";
 
 const challenges = [
   {
     challenge: "Disjointed upsells",
-    fix: "Pre-arrival emails offer stay personalisation, spa slots, parking and more.",
+    fix: "Pre-arrival emails present upgrades, parking, spa slots, and late checkout—automatically, no calls or manual chasing.",
   },
   {
-    challenge: "Room-service delays",
-    fix: "QR ordering routes tickets straight to kitchen/bar with throttling.",
+    challenge: "Guests asking the same questions",
+    fix: "Welcome messages and property guides arrive in guests’ inboxes before check-in, answering Wi-Fi, parking, spa hours, and more.",
   },
   {
-    challenge: "Missed guest requests",
-    fix: "One-tap service tickets auto-assign to housekeeping or engineering.",
+    challenge: "OTA dependency",
+    fix: "Post-stay thank-you emails with rebook links capture more direct bookings and verified reviews.",
   },
   {
-    challenge: "OTA review pressure",
-    fix: "Verified EMS Rate reviews lift scores & drive direct bookings.",
+    challenge: "Operational bottlenecks",
+    fix: "Orders route instantly to the right department via fulfilment dashboards and calendar-linked scheduling.",
   },
 ];
 
-const modules = [
+const journey = [
   {
-    icon: Utensils,
-    title: "Digital Ordering",
-    description: "Room service, poolside drinks, restaurant table ordering.",
-  },
-    {
-    icon: ConciergeBell,
-    title: "Service Requests",
-    description: "Extra pillow, maintenance, airport transfer—logged & tracked.",
+    stage: "Pre-Arrival",
+    description:
+      "A polished email introducing the stay, upselling add-ons, and linking to local guides.",
   },
   {
-    icon: Info,
-    title: "Info Pages",
-    description: "Local guides, spa menus, Wi-Fi codes—all branded to you.",
+    stage: "In-Stay",
+    description:
+      "Mid-stay touchpoints with local recs, dining reminders, or late checkout prompts.",
   },
   {
-    icon: MessageCircle,
-    title: "Live Chat",
-    description: "Real-time concierge routed to the right team.",
+    stage: "Post-Stay",
+    description:
+      "Thank-you emails that secure reviews and encourage direct rebooking.",
   },
 ];
 
 const staffFeatures = [
   {
-    icon: LayoutGrid,
-    title: "Live fulfilment boards",
-    description: "Colour-coded cards by team, priority, and SLA.",
+    icon: Users,
+    title: "Fulfilment dashboards",
+    description: "Track and assign upsell requests with clear SLAs.",
   },
   {
-    icon: Shuffle,
-    title: "Auto-routing rules",
-    description: "“Broken AC” ➜ Engineering · “Extra towels” ➜ Housekeeping.",
+    icon: Calendar,
+    title: "Calendar-linked products",
+    description:
+      "Manage bookable assets (spa slots, bike rentals, meeting rooms) without double-booking.",
   },
   {
-    icon: BarChart2,
-    title: "Exportable revenue reports",
-    description: "CSV or scheduled PDFs for finance & owners.",
+    icon: TrendingUp,
+    title: "Real-time insights",
+    description: "See revenue, take-rates, and product performance at a glance.",
   },
   {
-    icon: CalendarDays,
-    title: "Calendar view",
-    description: "Spa appointments, meeting-room bookings, equipment loans.",
+    icon: Mail,
+    title: "CSV/PMS sync",
+    description:
+      "Start small with spreadsheet uploads or connect your PMS for full automation.",
   },
-];
-
-const touchpoints = [
-  { stage: "Pre-arrival", exp: "Upgrade & add-on email" },
-  { stage: "In-stay", exp: "QR room-service + live chat" },
-  { stage: "Checkout", exp: "Automated review prompt" },
 ];
 
 export default function Page() {
@@ -94,7 +82,7 @@ export default function Page() {
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
           title="Digitise Every Stay, Your Way"
-          subtitle="Give guests mobile-first options for check-in, room-service, chat, and upsells while staff handle it all from one easy dashboard."
+          subtitle="Hospitality thrives on moments. EMS makes those moments easier to deliver by automating personalised emails before, during, and after each stay. Guests get clear info, tempting upgrades, and local recommendations—staff get a clean dashboard to fulfil, track, and measure everything."
         >
           <Button
             size="lg"
@@ -110,46 +98,33 @@ export default function Page() {
             <CalendarDays className="h-5 w-5" /> Book a Demo
           </Button>
         </PageHero>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Why Hoteliers Choose EMS</h2>
-          <div className="grid md:grid-cols-2 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+          <div className="grid md:grid-cols-2 gap-4">
             {challenges.map((row) => (
-              <div key={row.challenge} className="border p-6 -mt-px -ml-px space-y-1">
+              <Card key={row.challenge} className="p-6 space-y-1">
                 <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
                 <p className="font-semibold">{row.challenge}</p>
                 <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
                 <p className="text-sm">{row.fix}</p>
-              </div>
+              </Card>
             ))}
           </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">“Pick & Mix” Your Perfect Guest Journey</h2>
-          {/* Mobile/Tablet layout */}
-          <div className="flex flex-wrap justify-center gap-4 md:hidden">
-            {modules.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-                className="w-full sm:w-1/2"
-              />
+          <h2 className="text-2xl font-semibold">Build the Guest Journey That Fits You</h2>
+          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+            {journey.map((item) => (
+              <Card key={item.stage} className="p-6 text-center space-y-2">
+                <p className="text-lg font-semibold">{item.stage}</p>
+                <p className="text-sm text-foreground/80">{item.description}</p>
+              </Card>
             ))}
           </div>
-          {/* Desktop layout: two rows of two cards */}
-          <div className="hidden md:grid grid-cols-2 gap-4">
-            {modules.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
-          </div>
-          <p>Activate only the modules you need today; add more anytime with one click.</p>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Effortless for Staff</h2>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -163,24 +138,33 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Guest Journey Touchpoints</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-3 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
-            {touchpoints.map((row) => (
-              <div key={row.stage} className="border p-6 -mt-px -ml-px">
-                <div className="font-semibold">{row.stage}</div>
-                <p className="mt-2 text-sm xs:text-base">{row.exp}</p>
-              </div>
-            ))}
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <p className="text-lg font-semibold">
+            “Guests love the personal touch, staff love the simplicity—and the bottom line loves the upsells.”
+          </p>
+          <p>— GM, London Hotel Chain</p>
+        </section>
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+          <p>Drop the manual upselling. EMS automates the journey and keeps it human.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+            <Button
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+            >
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+            >
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Button>
           </div>
         </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
-          <p className="text-lg font-semibold">
-            “Guests love the control, staff love the simplicity—and revenues speak for themselves.”
-          </p>
-          <p className="mt-2">— GM, London Hotel Chain</p>
-        </section>
-        <CTABanner />
         <Footer />
       </main>
     </>

--- a/app/industries/restaurants/page.tsx
+++ b/app/industries/restaurants/page.tsx
@@ -1,84 +1,75 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
-import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
-  QrCode,
-  Utensils,
-  Activity,
-  Repeat,
-  LayoutGrid,
-  Info,
-  Pencil,
-  BarChart2,
   ArrowUpRight,
   CalendarDays,
+  Mail,
+  Calendar,
+  TrendingUp,
+  Users,
 } from "lucide-react";
 
 const challenges = [
   {
-    challenge: "Slow table turns",
-    fix: "QR table ordering with split-bill & tip options cuts dwell time.",
+    challenge: "Quiet midweek shifts",
+    fix: "Pre-arrival emails upsell chef’s menus, pairings, or promotions to drive midweek spend.",
   },
   {
-    challenge: "Menu questions",
-    fix: "Info QRs show allergens, provenance, and chef notes—no staff interruptions.",
+    challenge: "Guests unsure what to order",
+    fix: "Menus and recommendations shared automatically before arrival. No more PDF attachments.",
   },
   {
-    challenge: "Kitchen overload",
-    fix: "Fulfilment screens flag ageing tickets and let chefs pause items in a click.",
-  },
-  {
-    challenge: "Quiet mid-week shifts",
-    fix: "Pre-arrival upsell emails (welcome cocktail, chef’s menu) turn reservations into higher spend.",
+    challenge: "Lost loyalty",
+    fix: "Post-dining thank-you emails include review prompts and rebooking incentives to keep guests coming back.",
   },
 ];
 
 const journey = [
   {
-    icon: QrCode,
-    title: "Seat & Scan",
-    description: "Guests scan the table QR, browse, customise, and pay in seconds.",
+    stage: "Booking Confirmed",
+    description:
+      "Guests instantly receive a thank-you note + optional upsell (wine flight, welcome cocktail, prix fixe).",
   },
   {
-    icon: Utensils,
-    title: "Serve & Upsell",
-    description: "Smart add-on prompts (“Try truffle fries?”) boost basket size at checkout.",
+    stage: "Day Before",
+    description:
+      "Reminder email with chef highlights or local recommendations.",
   },
   {
-    icon: Activity,
-    title: "Pulse Feedback",
-    description: "Automated EMS Rate email drops after dessert, capturing key verified feedback",
+    stage: "Day After",
+    description: "Thank-you + review prompt.",
   },
   {
-    icon: Repeat,
-    title: "Retarget & Return",
-    description: "Next-day EMS Send email offers an exclusive weekday lunch deal to fill slow shifts.",
+    stage: "Week After",
+    description:
+      "Targeted email offering midweek specials or return booking discounts.",
   },
 ];
 
 const tools = [
   {
-    icon: LayoutGrid,
-    title: "Live fulfilment boards",
-    description: "Colour-coded timers spotlight orders that need attention.",
+    icon: Users,
+    title: "Fulfilment dashboards",
+    description: "Track pre-orders and make sure they’re delivered smoothly.",
   },
   {
-    icon: Info,
-    title: "Allergy & Provenance QRs",
-    description: "One tap reveals a full allergen matrix and farm-to-fork stories.",
+    icon: Calendar,
+    title: "Calendar-linked slots",
+    description: "Sell tasting menus or experiences tied to dates/times.",
   },
   {
-    icon: Pencil,
-    title: "Instant menu edits",
-    description: "86 an item or update pricing across every QR in under 10 seconds.",
-  },
-  {
-    icon: BarChart2,
+    icon: TrendingUp,
     title: "Revenue dashboards",
-    description: "Track per-cover spend, order flow, and upsell conversion in real time.",
+    description: "Monitor per-cover spend, upsell conversion, and campaign ROI.",
+  },
+  {
+    icon: Mail,
+    title: "Menu links in emails",
+    description: "Easily share menus or allergen info without staff emails.",
   },
 ];
 
@@ -88,8 +79,8 @@ export default function Page() {
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
-          title="Turn every table into a revenue engine."
-          subtitle="Give guests friction-free ordering, rich storytelling, and irresistible pre-arrival upsells while your team stays in full control."
+          title="Turn Every Reservation Into Revenue"
+          subtitle="From the moment a guest books, EMS can work in the background. Share menus, allergen info, chef’s notes, or upsell experiences like welcome cocktails or set menus. After the meal, EMS collects reviews and entices guests back for the next booking."
         >
           <Button
             size="lg"
@@ -105,32 +96,33 @@ export default function Page() {
             <CalendarDays className="h-5 w-5" /> Book a Demo
           </Button>
         </PageHero>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Why Operators Love EMS</h2>
-          <div className="grid md:grid-cols-2 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+          <div className="grid md:grid-cols-2 gap-4">
             {challenges.map((row) => (
-              <div key={row.challenge} className="border p-6 -mt-px -ml-px space-y-1">
+              <Card key={row.challenge} className="p-6 space-y-1">
                 <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
                 <p className="font-semibold">{row.challenge}</p>
                 <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
                 <p className="text-sm">{row.fix}</p>
-              </div>
+              </Card>
             ))}
           </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">“Seat-to-Repeat” Guest Journey</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
+          <h2 className="text-2xl font-semibold">Seat-to-Repeat Guest Journey</h2>
+          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
             {journey.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
+              <Card key={item.stage} className="p-6 space-y-2 text-center">
+                <p className="text-lg font-semibold">{item.stage}</p>
+                <p className="text-sm text-foreground/80">{item.description}</p>
+              </Card>
             ))}
           </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
           <h2 className="text-2xl font-semibold">Tools That Delight Guests and Staff</h2>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -144,11 +136,33 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
-          <p className="text-lg font-semibold">“Guests love the control, staff love the calm—and we bank the upsells.”</p>
-          <p className="mt-2">— Operations Director, Warwickshire Bistro</p>
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <p className="text-lg font-semibold">
+            “Guests arrive primed to spend more, and staff stay focused on service. Upsells now feel effortless.”
+          </p>
+          <p>— Ops Director, Warwickshire Bistro</p>
         </section>
-        <CTABanner />
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+          <p>Turn every cover into repeat business with automated flows.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+            <Button
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+            >
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+            >
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Button>
+          </div>
+        </section>
         <Footer />
       </main>
     </>

--- a/app/industries/venues/page.tsx
+++ b/app/industries/venues/page.tsx
@@ -1,65 +1,72 @@
 import PageHero from "@/components/page-hero";
 import Footer from "@/components/footer";
-import CTABanner from "@/components/cta-banner";
 import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import {
   ArrowUpRight,
   CalendarDays,
-  LayoutGrid,
-  Pause,
-  Filter,
-  BookOpen,
+  Mail,
+  Calendar,
+  TrendingUp,
+  Users,
 } from "lucide-react";
 
 const challenges = [
   {
-    challenge: "Pre-event upsells",
-    fix: "EMS Send emails upselling VIP parking, seat upgrades, or pre-ordered drinks.",
+    challenge: "Missed pre-event sales",
+    fix: "Emails upsell VIP upgrades, parking passes, drink tokens, or meal deals before guests even arrive.",
   },
   {
-    challenge: "Concession queues",
-    fix: "Seat & Collect QRs let guests order on their phone—either delivered to seats or prepped for fast pickup.",
+    challenge: "Confused attendees",
+    fix: "Automated info packs cover set times, maps, travel advice, and FAQs in one click.",
   },
   {
-    challenge: "Info overload",
-    fix: "Info QRs surface set times, maps, allergen lists, or ward visiting hours instantly.",
-  },
-  {
-    challenge: "Missed merch sales",
-    fix: "Post-event EMS Send nudges fans who didn’t buy on-site with a “Missed the merch?” link.",
+    challenge: "Weak post-event conversion",
+    fix: "Follow-up emails with merch, future event offers, or memberships lock in extra revenue.",
   },
 ];
 
 const journey = [
-  { stage: "Ticket purchase", exp: "Auto-welcome email with FAQ & VIP add-ons" },
-  { stage: "In-seat", exp: "QR ordering (delivery or collect)" },
-  { stage: "Set-time alert", exp: "Push: “Bar closes in 15 min—last orders now”" },
-  { stage: "Exit", exp: "Feedback & merch discount" },
-  { stage: "Day +1", exp: "Follow-up email: missed-merch, season tickets" },
+  {
+    stage: "Ticket Purchase",
+    description: "Welcome email + optional VIP/product upsells.",
+  },
+  {
+    stage: "T-1 Week",
+    description: "Event info + transport details.",
+  },
+  {
+    stage: "Day Before",
+    description: "Reminder email upselling drink tokens or meal packages.",
+  },
+  {
+    stage: "Post-Event",
+    description: "Thank-you + review + “missed merch” follow-up.",
+  },
 ];
 
 const tools = [
   {
-    icon: LayoutGrid,
-    title: "Live fulfilment screens",
-    description: "Colour-coded timers flag ageing orders and help staff pace volume.",
+    icon: Users,
+    title: "Fulfilment dashboards",
+    description: "Manage pre-event product redemptions and orders.",
   },
   {
-    icon: Pause,
-    title: "Pause / Resume menu items",
-    description: "Run out of nachos? Hide them in two taps—auto-message explains to guests.",
+    icon: Calendar,
+    title: "Calendar-linked inventory",
+    description: "Limit ticketed upsells like VIP meet & greet or parking slots.",
   },
   {
-    icon: Filter,
-    title: "Segmented EMS Send",
-    description: "Target by seat block, membership tier, or day-patient ward.",
+    icon: Mail,
+    title: "Segmented sends",
+    description: "Target communications by ticket type, seating block, or membership level.",
   },
   {
-    icon: BookOpen,
-    title: "QR story cards",
-    description: "Showcase provenance of craft beers, artist bios, or post-op recovery advice.",
+    icon: TrendingUp,
+    title: "Insights dashboards",
+    description: "See take-rates, AOV, and campaign impact instantly.",
   },
 ];
 
@@ -69,8 +76,8 @@ export default function Page() {
       <Navbar />
       <main className="pt-16 xs:pt-20 sm:pt-24">
         <PageHero
-          title="Craft seamless guest experiences."
-          subtitle="Stadiums, theatres, arenas, festivals, even private hospitals—EMS puts ticketing, on-site ordering, and follow-up revenue under one roof."
+          title="Craft Seamless Guest Journeys"
+          subtitle="For arenas, theatres, stadiums, and events, EMS automates communication from ticket purchase through encore. Guests get clarity and offers; your team gets predictable pre-orders and revenue uplift."
         >
           <Button
             size="lg"
@@ -86,33 +93,33 @@ export default function Page() {
             <CalendarDays className="h-5 w-5" /> Book a Demo
           </Button>
         </PageHero>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
           <h2 className="text-2xl font-semibold">Why Operators Choose EMS</h2>
-          <div className="grid md:grid-cols-2 bg-background rounded-xl overflow-hidden outline outline-[1px] outline-border outline-offset-[-1px]">
+          <div className="grid md:grid-cols-2 gap-4">
             {challenges.map((row) => (
-              <div key={row.challenge} className="border p-6 -mt-px -ml-px space-y-1">
+              <Card key={row.challenge} className="p-6 space-y-1">
                 <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
                 <p className="font-semibold">{row.challenge}</p>
                 <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
                 <p className="text-sm">{row.fix}</p>
-              </div>
+              </Card>
             ))}
           </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">“Door-to-Encore” Journey</h2>
-          <ol className="relative border-l border-border pl-6 space-y-6">
-            {journey.map((row) => (
-              <li key={row.stage} className="relative">
-                <span className="absolute -left-3 top-4 h-2 w-2 rounded-full bg-primary" />
-                <div className="bg-background border rounded-xl p-4 ml-2">
-                  <p className="text-sm font-semibold">{row.stage}</p>
-                  <p className="text-sm text-foreground/80">{row.exp}</p>
-                </div>
-              </li>
+          <h2 className="text-2xl font-semibold">Door-to-Encore Guest Journey</h2>
+          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+            {journey.map((item) => (
+              <Card key={item.stage} className="p-6 text-center space-y-2">
+                <p className="text-lg font-semibold">{item.stage}</p>
+                <p className="text-sm text-foreground/80">{item.description}</p>
+              </Card>
             ))}
-          </ol>
+          </div>
         </section>
+
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
           <h2 className="text-2xl font-semibold">Tools That Keep Crowds Happy and Ops Calm</h2>
           <div className="grid sm:grid-cols-2 gap-4">
@@ -126,11 +133,33 @@ export default function Page() {
             ))}
           </div>
         </section>
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center">
-          <p className="text-lg font-semibold">“Queues vanished, bar sales soared, and fans loved the control.”</p>
-          <p className="mt-2">— F&B Manager, Midlands Arena</p>
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <p className="text-lg font-semibold">
+            “Queues fell, per-head spend rose, and we’ve built repeatable revenue into every event.”
+          </p>
+          <p>— F&B Manager, Midlands Arena</p>
         </section>
-        <CTABanner />
+
+        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
+          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+          <p>Upgrade every touchpoint, not just the stage.</p>
+          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+            <Button
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+            >
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Button>
+            <Button
+              variant="outline"
+              size="lg"
+              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+            >
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Button>
+          </div>
+        </section>
         <Footer />
       </main>
     </>

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-xl border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+export { Card };


### PR DESCRIPTION
## Summary
- add reusable Card component for challenge blocks
- refresh hotel, restaurant, venue, and Airbnb pages with new marketing copy, feature icons, and CTAs
- rewrite About Us page with updated story, mission, and audience

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed8279f44832dbaa7f55fa01835a3