### PR TITLE
refactor: unify styling, rebuild features pages, fix pricing & build issues

### DIFF
--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
         <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6 text-center">
           <h2 className="text-2xl font-semibold">Book a 30-Minute Demo</h2>
           <p>
-            See EMS in action—pre-arrival upsells, QR ordering, verified reviews, and real-time dashboards—all in one call.
+            See EMS in action—pre-arrival upsells, guest guides, fulfilment tools and real-time dashboards—all in one call.
           </p>
           <div className="border rounded-lg p-2">
             <div

--- a/app/emails/page.tsx
+++ b/app/emails/page.tsx
@@ -3,6 +3,8 @@ import FeatureCard from "@/components/feature-card";
 import { Navbar } from "@/components/navbar";
 import Footer from "@/components/footer";
 import { Button } from "@/components/ui/button";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -20,6 +22,12 @@ import {
   Timer,
   Layers,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Automated Engagement | EMS",
+  description:
+    "Pre-timed, branded email flows that guide guests and drive upsells before, during and after their stay.",
+};
 
 export default function Page() {
   const benefits = [
@@ -158,7 +166,7 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Why Automated Engagement Matters
           </h2>
@@ -172,9 +180,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             What You Can Automate
           </h2>
@@ -188,9 +196,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             How It Works
           </h2>
@@ -204,9 +212,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Why Teams Love It
           </h2>
@@ -220,35 +228,37 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-12 max-w-screen-md mx-auto text-center space-y-4">
-          <blockquote className="border-l-4 pl-4 italic text-left">
-            “Pre-arrival emails now do the selling for us. Upgrades, parking,
-            late checkout—+17% ancillary within a month.”
-            <br />— GM, 74-room Boutique Hotel, Bath
-          </blockquote>
-          <p>
-            Automated Engagement is the foundation of modern guest experience.
-            <br />Inform them, inspire them, upsell them—without lifting a
-            finger.
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <blockquote className="border-l-4 pl-4 italic text-left">
+              “Pre-arrival emails now do the selling for us. Upgrades, parking,
+              late checkout—+17% ancillary within a month.”
+              <br />— GM, 74-room Boutique Hotel, Bath
+            </blockquote>
+            <p>
+              Automated Engagement is the foundation of modern guest experience.
+              <br />Inform them, inspire them, upsell them—without lifting a
+              finger.
+            </p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
           </div>
-        </section>
+        </Section>
 
         <Footer />
       </main>

--- a/app/fulfilment/page.tsx
+++ b/app/fulfilment/page.tsx
@@ -3,6 +3,8 @@ import FeatureCard from "@/components/feature-card";
 import { Navbar } from "@/components/navbar";
 import Footer from "@/components/footer";
 import { Button } from "@/components/ui/button";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -26,6 +28,12 @@ import {
   ListChecks,
   TrendingUp,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Fulfilment | EMS",
+  description:
+    "Route upsell requests to the right team, track progress with SLAs and keep every promise to guests.",
+};
 
 export default function Page() {
   const why = [
@@ -180,7 +188,7 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Why Fulfilment Matters
           </h2>
@@ -194,9 +202,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             What Fulfilment Covers
           </h2>
@@ -210,9 +218,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Real Use Cases
           </h2>
@@ -226,9 +234,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Staff View Benefits
           </h2>
@@ -242,9 +250,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Manager View Benefits
           </h2>
@@ -258,31 +266,33 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-12 max-w-screen-md mx-auto text-center space-y-4">
-          <blockquote className="border-l-4 pl-4 italic text-left">
-            “Guests love the tone; ops loves the quiet inbox. The guide email
-            cut questions by half.”
-            <br />— Ops Manager, Countryside Hotel
-          </blockquote>
-          <p>Fulfilment is where promises meet reality. EMS makes sure you deliver.</p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <blockquote className="border-l-4 pl-4 italic text-left">
+              “Guests love the tone; ops loves the quiet inbox. The guide email
+              cut questions by half.”
+              <br />— Ops Manager, Countryside Hotel
+            </blockquote>
+            <p>Fulfilment is where promises meet reality. EMS makes sure you deliver.</p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
           </div>
-        </section>
+        </Section>
 
         <Footer />
       </main>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;700&display=swap');
-@import url('https://api.fontshare.com/v2/css?f[]=clash-display@700&display=swap');
+@import url('https://api.fontshare.com/v2/css?f[]=clash-display@700&f[]=inter@400,500,600&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -58,7 +57,9 @@
 
     --chart-5: 27 87% 67%;
 
-    --radius: 0.5rem
+    --radius: 0.5rem;
+    --font-heading: 'Clash Display', sans-serif;
+    --font-sans: 'Inter', sans-serif;
   }
 }
 
@@ -72,12 +73,9 @@
     @apply scroll-smooth scroll-pt-12;
   }
   body {
-    @apply text-foreground;
-    font-family: 'Poppins', sans-serif;
+    @apply text-foreground font-sans;
   }
   h1, h2, h3, h4, h5, h6 {
-    font-family: 'Clash Display', sans-serif;
-    font-weight: 700;
-    text-transform: uppercase;
+    @apply font-heading font-bold uppercase;
   }
 }

--- a/app/industries/airbnbs/page.tsx
+++ b/app/industries/airbnbs/page.tsx
@@ -4,6 +4,8 @@ import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -12,6 +14,12 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Airbnbs | EMS",
+  description:
+    "Automate guest emails, upsell local extras and manage fulfilment for short-term rentals and Airbnbs.",
+};
 
 const challenges = [
   {
@@ -98,72 +106,82 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Why Hosts &amp; Managers Choose EMS</h2>
-          <div className="grid md:grid-cols-2 gap-4">
-            {challenges.map((row) => (
-              <Card key={row.challenge} className="p-6 space-y-1">
-                <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
-                <p className="font-semibold">{row.challenge}</p>
-                <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
-                <p className="text-sm">{row.fix}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Why Hosts &amp; Managers Choose EMS</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {challenges.map((row) => (
+                <Card key={row.challenge} className="p-6 space-y-1">
+                  <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
+                  <p className="font-semibold">{row.challenge}</p>
+                  <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
+                  <p className="text-sm">{row.fix}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Booking-to-Rebooking Guest Journey</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-4">
-            {journey.map((item) => (
-              <Card key={item.stage} className="p-6 text-center space-y-2">
-                <p className="text-lg font-semibold">{item.stage}</p>
-                <p className="text-sm text-foreground/80">{item.description}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Booking-to-Rebooking Guest Journey</h2>
+            <div className="grid sm:grid-cols-2 md:grid-cols-5 gap-4">
+              {journey.map((item) => (
+                <Card key={item.stage} className="p-6 text-center space-y-2">
+                  <p className="text-lg font-semibold">{item.stage}</p>
+                  <p className="text-sm text-foreground/80">{item.description}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Tools That Keep Hosts Happy</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {tools.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Tools That Keep Hosts Happy</h2>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {tools.map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <p className="text-lg font-semibold">
-            “EMS turned endless questions into smooth self-service—and new revenue streams we never thought to try.”
-          </p>
-          <p>— Anna Doyle, Superhost</p>
-        </section>
-
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
-          <p>Get more revenue and fewer headaches—without hiring more staff.</p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <p className="text-lg font-semibold">
+              “EMS turned endless questions into smooth self-service—and new revenue streams we never thought to try.”
+            </p>
+            <p>— Anna Doyle, Superhost</p>
           </div>
-        </section>
+        </Section>
+
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+            <p>Get more revenue and fewer headaches—without hiring more staff.</p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
+          </div>
+        </Section>
         <Footer />
       </main>
     </>

--- a/app/industries/hotels/page.tsx
+++ b/app/industries/hotels/page.tsx
@@ -4,6 +4,8 @@ import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -12,6 +14,12 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Hotels | EMS",
+  description:
+    "Automate guest comms and upsells while giving staff clear fulfilment dashboards across your hotel.",
+};
 
 const challenges = [
   {
@@ -99,72 +107,82 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Why Hoteliers Choose EMS</h2>
-          <div className="grid md:grid-cols-2 gap-4">
-            {challenges.map((row) => (
-              <Card key={row.challenge} className="p-6 space-y-1">
-                <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
-                <p className="font-semibold">{row.challenge}</p>
-                <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
-                <p className="text-sm">{row.fix}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Why Hoteliers Choose EMS</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {challenges.map((row) => (
+                <Card key={row.challenge} className="p-6 space-y-1">
+                  <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
+                  <p className="font-semibold">{row.challenge}</p>
+                  <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
+                  <p className="text-sm">{row.fix}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Build the Guest Journey That Fits You</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
-            {journey.map((item) => (
-              <Card key={item.stage} className="p-6 text-center space-y-2">
-                <p className="text-lg font-semibold">{item.stage}</p>
-                <p className="text-sm text-foreground/80">{item.description}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Build the Guest Journey That Fits You</h2>
+            <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
+              {journey.map((item) => (
+                <Card key={item.stage} className="p-6 text-center space-y-2">
+                  <p className="text-lg font-semibold">{item.stage}</p>
+                  <p className="text-sm text-foreground/80">{item.description}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Effortless for Staff</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {staffFeatures.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Effortless for Staff</h2>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {staffFeatures.map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <p className="text-lg font-semibold">
-            “Guests love the personal touch, staff love the simplicity—and the bottom line loves the upsells.”
-          </p>
-          <p>— GM, London Hotel Chain</p>
-        </section>
-
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
-          <p>Drop the manual upselling. EMS automates the journey and keeps it human.</p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <p className="text-lg font-semibold">
+              “Guests love the personal touch, staff love the simplicity—and the bottom line loves the upsells.”
+            </p>
+            <p>— GM, London Hotel Chain</p>
           </div>
-        </section>
+        </Section>
+
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+            <p>Drop the manual upselling. EMS automates the journey and keeps it human.</p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
+          </div>
+        </Section>
         <Footer />
       </main>
     </>

--- a/app/industries/restaurants/page.tsx
+++ b/app/industries/restaurants/page.tsx
@@ -4,6 +4,8 @@ import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -12,6 +14,12 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Restaurants | EMS",
+  description:
+    "Automate pre- and post-dining emails, share menus and track fulfilment to boost restaurant revenue.",
+};
 
 const challenges = [
   {
@@ -97,72 +105,82 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Why Operators Love EMS</h2>
-          <div className="grid md:grid-cols-2 gap-4">
-            {challenges.map((row) => (
-              <Card key={row.challenge} className="p-6 space-y-1">
-                <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
-                <p className="font-semibold">{row.challenge}</p>
-                <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
-                <p className="text-sm">{row.fix}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Why Operators Love EMS</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {challenges.map((row) => (
+                <Card key={row.challenge} className="p-6 space-y-1">
+                  <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
+                  <p className="font-semibold">{row.challenge}</p>
+                  <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
+                  <p className="text-sm">{row.fix}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Seat-to-Repeat Guest Journey</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-            {journey.map((item) => (
-              <Card key={item.stage} className="p-6 space-y-2 text-center">
-                <p className="text-lg font-semibold">{item.stage}</p>
-                <p className="text-sm text-foreground/80">{item.description}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Seat-to-Repeat Guest Journey</h2>
+            <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+              {journey.map((item) => (
+                <Card key={item.stage} className="p-6 space-y-2 text-center">
+                  <p className="text-lg font-semibold">{item.stage}</p>
+                  <p className="text-sm text-foreground/80">{item.description}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Tools That Delight Guests and Staff</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {tools.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Tools That Delight Guests and Staff</h2>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {tools.map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <p className="text-lg font-semibold">
-            “Guests arrive primed to spend more, and staff stay focused on service. Upsells now feel effortless.”
-          </p>
-          <p>— Ops Director, Warwickshire Bistro</p>
-        </section>
-
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
-          <p>Turn every cover into repeat business with automated flows.</p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <p className="text-lg font-semibold">
+              “Guests arrive primed to spend more, and staff stay focused on service. Upsells now feel effortless.”
+            </p>
+            <p>— Ops Director, Warwickshire Bistro</p>
           </div>
-        </section>
+        </Section>
+
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+            <p>Turn every cover into repeat business with automated flows.</p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
+          </div>
+        </Section>
         <Footer />
       </main>
     </>

--- a/app/industries/venues/page.tsx
+++ b/app/industries/venues/page.tsx
@@ -4,6 +4,8 @@ import { Navbar } from "@/components/navbar";
 import FeatureCard from "@/components/feature-card";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -12,6 +14,12 @@ import {
   TrendingUp,
   Users,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Venues | EMS",
+  description:
+    "Automate event comms, upsell VIP options and manage redemptions with fulfilment dashboards for venues.",
+};
 
 const challenges = [
   {
@@ -94,72 +102,82 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-6">
-          <h2 className="text-2xl font-semibold">Why Operators Choose EMS</h2>
-          <div className="grid md:grid-cols-2 gap-4">
-            {challenges.map((row) => (
-              <Card key={row.challenge} className="p-6 space-y-1">
-                <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
-                <p className="font-semibold">{row.challenge}</p>
-                <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
-                <p className="text-sm">{row.fix}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-6">
+            <h2 className="text-2xl font-semibold">Why Operators Choose EMS</h2>
+            <div className="grid md:grid-cols-2 gap-4">
+              {challenges.map((row) => (
+                <Card key={row.challenge} className="p-6 space-y-1">
+                  <p className="text-[#F65053] text-xs font-semibold">Challenge</p>
+                  <p className="font-semibold">{row.challenge}</p>
+                  <p className="mt-3 text-[#F65053] text-xs font-semibold">EMS Fix</p>
+                  <p className="text-sm">{row.fix}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Door-to-Encore Guest Journey</h2>
-          <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
-            {journey.map((item) => (
-              <Card key={item.stage} className="p-6 text-center space-y-2">
-                <p className="text-lg font-semibold">{item.stage}</p>
-                <p className="text-sm text-foreground/80">{item.description}</p>
-              </Card>
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Door-to-Encore Guest Journey</h2>
+            <div className="grid sm:grid-cols-2 md:grid-cols-4 gap-4">
+              {journey.map((item) => (
+                <Card key={item.stage} className="p-6 text-center space-y-2">
+                  <p className="text-lg font-semibold">{item.stage}</p>
+                  <p className="text-sm text-foreground/80">{item.description}</p>
+                </Card>
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto space-y-4">
-          <h2 className="text-2xl font-semibold">Tools That Keep Crowds Happy and Ops Calm</h2>
-          <div className="grid sm:grid-cols-2 gap-4">
-            {tools.map((item) => (
-              <FeatureCard
-                key={item.title}
-                icon={item.icon}
-                title={item.title}
-                description={item.description}
-              />
-            ))}
+        <Section>
+          <div className="max-w-screen-md mx-auto space-y-4">
+            <h2 className="text-2xl font-semibold">Tools That Keep Crowds Happy and Ops Calm</h2>
+            <div className="grid sm:grid-cols-2 gap-4">
+              {tools.map((item) => (
+                <FeatureCard
+                  key={item.title}
+                  icon={item.icon}
+                  title={item.title}
+                  description={item.description}
+                />
+              ))}
+            </div>
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <p className="text-lg font-semibold">
-            “Queues fell, per-head spend rose, and we’ve built repeatable revenue into every event.”
-          </p>
-          <p>— F&B Manager, Midlands Arena</p>
-        </section>
-
-        <section className="px-6 py-10 max-w-screen-md mx-auto text-center space-y-4">
-          <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
-          <p>Upgrade every touchpoint, not just the stage.</p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <p className="text-lg font-semibold">
+              “Queues fell, per-head spend rose, and we’ve built repeatable revenue into every event.”
+            </p>
+            <p>— F&B Manager, Midlands Arena</p>
           </div>
-        </section>
+        </Section>
+
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <h2 className="text-2xl font-semibold">The guest experience is evolving. Are you?</h2>
+            <p>Upgrade every touchpoint, not just the stage.</p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
+          </div>
+        </Section>
         <Footer />
       </main>
     </>

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -3,6 +3,8 @@ import FeatureCard from "@/components/feature-card";
 import { Navbar } from "@/components/navbar";
 import Footer from "@/components/footer";
 import { Button } from "@/components/ui/button";
+import Section from "@/components/section";
+import type { Metadata } from "next";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -22,6 +24,12 @@ import {
   BedDouble,
   UtensilsCrossed,
 } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "Insights | EMS",
+  description:
+    "Live dashboards that show revenue, engagement and product performance so you can optimise every campaign.",
+};
 
 export default function Page() {
   const why = [
@@ -149,7 +157,7 @@ export default function Page() {
           </Button>
         </PageHero>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Why Insights Matter
           </h2>
@@ -163,9 +171,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             What You&apos;ll See
           </h2>
@@ -179,9 +187,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             How Teams Use Insights
           </h2>
@@ -195,9 +203,9 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="w-full py-12 xs:py-20 px-6">
+        <Section>
           <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
             Real Use Cases
           </h2>
@@ -211,34 +219,36 @@ export default function Page() {
               />
             ))}
           </div>
-        </section>
+        </Section>
 
-        <section className="px-6 py-12 max-w-screen-md mx-auto text-center space-y-4">
-          <p>
-            Insights isn&apos;t just dashboards. It’s your feedback loop. Every
-            email you send feeds data back into EMS, giving you a constantly
-            improving revenue engine.
-          </p>
-          <p>
-            If you can measure it, you can grow it. EMS Insights makes sure you
-            do both.
-          </p>
-          <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
-            <Button
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
-            >
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
-            >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
-            </Button>
+        <Section>
+          <div className="max-w-screen-md mx-auto text-center space-y-4">
+            <p>
+              Insights isn&apos;t just dashboards. It’s your feedback loop. Every
+              email you send feeds data back into EMS, giving you a constantly
+              improving revenue engine.
+            </p>
+            <p>
+              If you can measure it, you can grow it. EMS Insights makes sure you
+              do both.
+            </p>
+            <div className="flex flex-col sm:flex-row justify-center gap-4 pt-4">
+              <Button
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
+              >
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Button>
+              <Button
+                variant="outline"
+                size="lg"
+                className="w-full sm:w-auto rounded-full text-base border-[#F65053] text-[#F65053]"
+              >
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Button>
+            </div>
           </div>
-        </section>
+        </Section>
 
         <Footer />
       </main>

--- a/components/faq.tsx
+++ b/components/faq.tsx
@@ -18,7 +18,7 @@ const faq = [
     icon: Truck,
     question: "Do I need to buy any new hardware?",
     answer:
-      "No, guests just scan a QR code on their phone. Staff can use their phones, tablets or laptops.",
+      "No. It's all browser-based, so staff can use their phones, tablets or laptops.",
   },
   {
     icon: ShieldCheck,
@@ -30,7 +30,7 @@ const faq = [
     icon: Route,
     question: "How long does setup take?",
     answer:
-      "You can start using EMS in minutes. Full customisation with products, requests, branding and live chat can take a couple of hours, depending on how complex you go.",
+      "You can start using EMS in minutes. Full customisation with products, requests and branding can take a couple of hours, depending on how complex you go.",
   },
   {
     icon: BadgeDollarSign,

--- a/components/feature-card.tsx
+++ b/components/feature-card.tsx
@@ -1,5 +1,7 @@
 import { LucideIcon } from "lucide-react";
 import React from "react";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 
 interface FeatureCardProps {
   icon: LucideIcon;
@@ -15,9 +17,7 @@ export default function FeatureCard({
   className,
 }: FeatureCardProps) {
   return (
-    <div
-      className={`flex flex-col bg-background border rounded-xl py-6 px-5 ${className || ""}`}
-    >
+    <Card className={cn("flex flex-col p-6", className)}>
       <div className="mb-3 h-10 w-10 flex items-center justify-center bg-muted rounded-full">
         <Icon className="h-6 w-6" />
       </div>
@@ -27,6 +27,6 @@ export default function FeatureCard({
       ) : (
         <div className="mt-1 text-foreground/80 text-[15px]">{description}</div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -1,6 +1,6 @@
 import {
   Workflow,
-  Link,
+  Link as LinkIcon,
   Store,
   Map,
   Handshake,
@@ -8,9 +8,35 @@ import {
   Upload,
   Send,
   ClipboardList,
+  Mail,
+  ClipboardCheck,
+  BarChart3,
 } from "lucide-react";
 import React from "react";
 import FeatureCard from "./feature-card";
+import Section from "./section";
+import Link from "next/link";
+
+const overview = [
+  {
+    icon: Mail,
+    title: "Automated Engagement",
+    description: "Pre-timed emails that guide and upsell.",
+    href: "/emails",
+  },
+  {
+    icon: ClipboardCheck,
+    title: "Fulfilment",
+    description: "Route orders with clear SLAs.",
+    href: "/fulfilment",
+  },
+  {
+    icon: BarChart3,
+    title: "Insights",
+    description: "See what converts and optimise.",
+    href: "/insights",
+  },
+];
 
 const features = [
   {
@@ -20,7 +46,7 @@ const features = [
       "Pre-built, perfectly timed automated upsell journeys.",
   },
   {
-    icon: Link,
+    icon: LinkIcon,
     title: "Seamless Embeds",
     description:
       "Drop your branded upsell microsite link into any email, SMS, or guest-platform message.",
@@ -121,8 +147,23 @@ const coreFeatures = [
 
 const Features = () => {
   return (
-    <div id="features" className="w-full py-12 xs:py-20 px-6">
+    <Section id="features">
       <h2 className="text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
+        Overview
+      </h2>
+      <div className="w-full max-w-screen-lg mx-auto mt-10 sm:mt-16 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {overview.map((item) => (
+          <Link key={item.title} href={item.href} className="h-full">
+            <FeatureCard
+              icon={item.icon}
+              title={item.title}
+              description={item.description}
+              className="h-full"
+            />
+          </Link>
+        ))}
+      </div>
+      <h2 className="mt-20 text-3xl xs:text-4xl sm:text-5xl font-bold tracking-tight text-center">
         Upsells Unleashed
       </h2>
       <div className="w-full max-w-screen-lg mx-auto mt-10 sm:mt-16 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -161,7 +202,7 @@ const Features = () => {
           />
         ))}
       </div>
-    </div>
+    </Section>
   );
 };
 

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -2,58 +2,55 @@
 
 
 import { Card } from "@/components/ui/card";
-]
+import Section from "@/components/section";
+
 export default function Pricing() {
   return (
-    <div id="pricing" className="flex flex-col items-center justify-center py-12 xs:py-20 px-6">
-
-      <h1 className="text-3xl xs:text-4xl md:text-5xl font-bold text-center tracking-tight">
-        Simple pricing. One clear price.
-      </h1>
-      <p className="mt-4 max-w-[60ch] xs:text-lg text-center">
-        Everything you need to unlock pre-arrival upsells, guest guides and fulfilment.
-      </p>
-      <div className="mt-8 w-full max-w-screen-md">
-
-        <Card className="bg-accent p-8 shadow flex flex-col items-center">
-
-          <div className="flex items-baseline justify-center gap-2">
-            <span className="text-5xl font-bold">£59</span>
-            <span className="text-lg font-semibold">/ property / month + VAT</span>
-          </div>
-          <div className="mt-8 w-full">
-            <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
-            <ul className="mt-4 space-y-2 text-sm md:text-base">
-              <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
-              <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
-              <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
-              <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
-              <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
-              <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
-              <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
-              <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
-              <li>✅ Multi-property management — Manage properties from one account.</li>
-              <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
-              <li>✅ 14-day free trial included</li>
-            </ul>
-          </div>
-          <div className="mt-8 w-full">
-            <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
-            <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
-              <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
-              <li>All plans charged + VAT.</li>
-              <li>Extra properties enjoy a 25% discount</li>
-            </ul>
-          </div>
-
-        </Card>
-
+    <Section id="pricing">
+      <div className="flex flex-col items-center justify-center">
+        <h1 className="text-3xl xs:text-4xl md:text-5xl font-bold text-center tracking-tight">
+          Simple pricing. One clear price.
+        </h1>
+        <p className="mt-4 max-w-[60ch] xs:text-lg text-center">
+          Everything you need to unlock pre-arrival upsells, guest guides and fulfilment.
+        </p>
+        <div className="mt-8 w-full max-w-screen-md">
+          <Card className="bg-accent p-8 flex flex-col items-center">
+            <div className="flex items-baseline justify-center gap-2">
+              <span className="text-5xl font-bold">£59</span>
+              <span className="text-lg font-semibold">/ property / month + VAT</span>
+            </div>
+            <div className="mt-8 w-full">
+              <h2 className="text-xl font-semibold text-center">What’s included (per property):</h2>
+              <ul className="mt-4 space-y-2 text-sm md:text-base">
+                <li>✅ Unlimited automations — Pre-, in- and post-stay journeys; unlimited sends.</li>
+                <li>✅ Branded upsell microsite — Your logo, fonts and colours.</li>
+                <li>✅ Advanced guest guides — Property info, welcome messages and local recommendations.</li>
+                <li>✅ Calendar-linked products — Sell anything that needs a time slot e.g. bike rental, picnic slots etc.</li>
+                <li>✅ Fulfilment dashboards — View orders in real-time and easily update the status.</li>
+                <li>✅ Live reporting & insights — Revenue, open rates, popular products, best customers.</li>
+                <li>✅ CSV upload + 1-click PMS sync — Start with CSVs; connect SiteMinder/HLS etc.</li>
+                <li>✅ Embed links & widgets — Drop the upsell link in emails, SMS or PMS messages.</li>
+                <li>✅ Multi-property management — Manage properties from one account.</li>
+                <li>✅ White-glove onboarding — Strategy call, setup help and optimisation check-ins.</li>
+                <li>✅ 14-day free trial included</li>
+              </ul>
+            </div>
+            <div className="mt-8 w-full">
+              <h2 className="text-xl font-semibold text-center">Processing & billing:</h2>
+              <ul className="mt-4 space-y-1 text-sm md:text-base list-disc list-inside">
+                <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
+                <li>All plans charged + VAT.</li>
+                <li>Extra properties enjoy a 25% discount</li>
+              </ul>
+            </div>
+          </Card>
+        </div>
+        <p className="mt-8 text-center text-sm text-muted-foreground max-w-[80ch]">
+          Need volume pricing or enterprise terms? Contact us - we offer custom discounts for larger portfolios and dedicated support packages.
+        </p>
       </div>
-      <p className="mt-8 text-center text-sm text-muted-foreground max-w-[80ch]">
-        Need volume pricing or enterprise terms? Contact us - we offer custom discounts for larger portfolios and dedicated support packages.
-      </p>
-
-    </div>
+    </Section>
   );
 }
 

--- a/components/section.tsx
+++ b/components/section.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils";
+import React from "react";
+
+type SectionProps = React.HTMLAttributes<HTMLElement>;
+
+export default function Section({ className, children, ...props }: SectionProps) {
+  return (
+    <section className={cn("py-12 xs:py-20", className)} {...props}>
+      <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">{children}</div>
+    </section>
+  );
+}

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -8,8 +8,10 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("rounded-2xl border bg-background text-foreground shadow", className)}
-
+      className={cn(
+        "rounded-2xl border bg-background/60 text-foreground backdrop-blur transition-shadow hover:shadow-sm",
+        className,
+      )}
       {...props}
     />
   )

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.3",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,7 +8,16 @@ export default {
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
+    container: {
+      center: true,
+      padding: "1rem",
+      screens: { "2xl": "1400px" },
+    },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", "sans-serif"],
+        heading: ["var(--font-heading)", "sans-serif"],
+      },
       colors: {
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",


### PR DESCRIPTION
## Summary
- add reusable Section layout and update cards for consistent rounded-2xl styling
- rebuild feature and industry pages with new overview links and refined copy
- normalize fonts and pricing, remove deprecated references

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aee9346ba4832db5d08a8f14d8f7db