### PR TITLE
Update CTA links to new registration and demo URLs

### DIFF
--- a/app/contact-us/page.tsx
+++ b/app/contact-us/page.tsx
@@ -51,7 +51,7 @@ export default function Page() {
           <div className="border rounded-lg p-2">
             <div
               className="calendly-inline-widget"
-              data-url="https://calendly.com/emsgrow"
+              data-url="https://calendly.com/emsgrow/30min"
               style={{ minWidth: "320px", height: "700px" }}
             />
           </div>

--- a/app/emails/page.tsx
+++ b/app/emails/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import Section from "@/components/section";
 import PatternedCta from "@/components/cta/PatternedCta";
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -153,17 +154,23 @@ export default function Page() {
           subtitle="Guests don’t want random newsletters—they want the right info at the right time. EMS turns your booking data into polished, branded email flows that guide, upsell, and delight."
         >
           <Button
+            asChild
             size="lg"
             className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
           >
-            Get Started Free <ArrowUpRight className="h-5 w-5" />
+            <Link href="https://enhancemystay.com/register">
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Link>
           </Button>
           <Button
+            asChild
             variant="contrast"
             size="lg"
             className="w-full sm:w-auto rounded-full text-base"
           >
-            <CalendarDays className="h-5 w-5" /> Book a Demo
+            <Link href="https://calendly.com/emsgrow/30min">
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Link>
           </Button>
         </PageHero>
 

--- a/app/fulfilment/page.tsx
+++ b/app/fulfilment/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import Section from "@/components/section";
 import PatternedCta from "@/components/cta/PatternedCta";
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -175,17 +176,23 @@ export default function Page() {
           subtitle="When a guest books a product or requests something, EMS makes sure your team delivers without bottlenecks."
         >
           <Button
+            asChild
             size="lg"
             className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
           >
-            Get Started Free <ArrowUpRight className="h-5 w-5" />
+            <Link href="https://enhancemystay.com/register">
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Link>
           </Button>
           <Button
+            asChild
             variant="contrast"
             size="lg"
             className="w-full sm:w-auto rounded-full text-base"
           >
-            <CalendarDays className="h-5 w-5" /> Book a Demo
+            <Link href="https://calendly.com/emsgrow/30min">
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Link>
           </Button>
         </PageHero>
 

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import Section from "@/components/section";
 import PatternedCta from "@/components/cta/PatternedCta";
 import type { Metadata } from "next";
+import Link from "next/link";
 import {
   ArrowUpRight,
   CalendarDays,
@@ -144,17 +145,23 @@ export default function Page() {
           subtitle="EMS Insights shows you in real-time what's working and what isn't so you can double down on what converts."
         >
           <Button
+            asChild
             size="lg"
             className="w-full sm:w-auto rounded-full text-base bg-[#F65053] hover:bg-[#F65053]/90"
           >
-            Get Started Free <ArrowUpRight className="h-5 w-5" />
+            <Link href="https://enhancemystay.com/register">
+              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            </Link>
           </Button>
           <Button
+            asChild
             variant="contrast"
             size="lg"
             className="w-full sm:w-auto rounded-full text-base"
           >
-            <CalendarDays className="h-5 w-5" /> Book a Demo
+            <Link href="https://calendly.com/emsgrow/30min">
+              <CalendarDays className="h-5 w-5" /> Book a Demo
+            </Link>
           </Button>
         </PageHero>
 

--- a/components/cta/PatternedCta.tsx
+++ b/components/cta/PatternedCta.tsx
@@ -48,14 +48,14 @@ export default function PatternedCta({ title, subtext, className }: PatternedCta
             <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
               {/* Primary */}
               <a
-                href="#get-started"
+                href="https://enhancemystay.com/register"
                 className="inline-flex h-11 items-center justify-center rounded-xl bg-primary px-5 text-primary-foreground hover:opacity-90 transition"
               >
                 Get Started Free
               </a>
               {/* Secondary */}
               <a
-                href="#demo"
+                href="https://calendly.com/emsgrow/30min"
                 className="inline-flex h-11 items-center justify-center rounded-xl border bg-white px-5 text-[#1A1A1A] hover:bg-white/90 transition"
               >
                 <span className="inline-flex items-center gap-2">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -5,7 +5,9 @@ import { ArrowUpRight, CalendarDays } from "lucide-react";
 import React from "react";
 
 import Image from "next/image";
+import Link from "next/link";
 import heroImage from "@/public/EMSHeroImage.png";
+import { AnimatedGridPattern } from "@/components/ui/animated-grid-pattern";
 
 
 const Hero = () => {
@@ -21,28 +23,30 @@ const Hero = () => {
             Automatically email guests before, during, and after their booking - or embed a link into your existing messages - to drive revenue and elevate the guest experience.
           </p>
           <div className="mt-12 flex flex-col sm:flex-row items-center sm:justify-start md:justify-start gap-4">
-            <Button size="lg" className="w-full sm:w-auto rounded-full text-base">
-              Get Started Free <ArrowUpRight className="!h-5 !w-5" />
+            <Button asChild size="lg" className="w-full sm:w-auto rounded-full text-base">
+              <Link href="https://enhancemystay.com/register">
+                Get Started Free <ArrowUpRight className="!h-5 !w-5" />
+              </Link>
             </Button>
             <Button
+              asChild
               variant="contrast"
               size="lg"
               className="w-full sm:w-auto rounded-full text-base shadow-none"
             >
-              <CalendarDays className="!h-5 !w-5" /> Book a Demo
+              <Link href="https://calendly.com/emsgrow/30min">
+                <CalendarDays className="!h-5 !w-5" /> Book a Demo
+              </Link>
             </Button>
           </div>
         </div>
-
-      </div>
-      <div className="md:w-1/2 flex justify-center mt-10 md:mt-0">
-        <Image
-      src={heroImage}
-      alt="EMS Hero"
-      className="w-full h-full object-contain rounded-3xl"
-      priority
-    />
-
+        <div className="md:w-1/2 flex justify-center mt-10 md:mt-0">
+          <Image
+            src={heroImage}
+            alt="EMS Hero"
+            className="w-full h-full object-contain rounded-3xl"
+            priority
+          />
         </div>
       </div>
     </section>

--- a/components/hero/Hero.tsx
+++ b/components/hero/Hero.tsx
@@ -3,6 +3,7 @@ import Section from "@/components/layout/Section";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { AnimatedGridPattern } from "@/components/ui/animated-grid-pattern";
+import Link from "next/link";
 
 interface HeroProps {
   eyebrow?: string;
@@ -46,15 +47,20 @@ export default function Hero({
               align === "center" ? "justify-center" : undefined
             )}
           >
-            <Button size="lg" className="rounded-full text-base">
-              Get Started Free <ArrowUpRight className="h-5 w-5" />
+            <Button asChild size="lg" className="rounded-full text-base">
+              <Link href="https://enhancemystay.com/register">
+                Get Started Free <ArrowUpRight className="h-5 w-5" />
+              </Link>
             </Button>
             <Button
+              asChild
               variant="contrast"
               size="lg"
               className="rounded-full text-base"
             >
-              <CalendarDays className="h-5 w-5" /> Book a Demo
+              <Link href="https://calendly.com/emsgrow/30min">
+                <CalendarDays className="h-5 w-5" /> Book a Demo
+              </Link>
             </Button>
           </div>
         )}

--- a/components/navbar/navbar.tsx
+++ b/components/navbar/navbar.tsx
@@ -15,10 +15,12 @@ const Navbar = () => {
         <div className="flex items-center gap-3">
           {/* Desktop Menu */}
           <NavMenu className="hidden md:block" />
-          <Button variant="outline" className="hidden sm:inline-flex">
-            Sign In
+          <Button asChild variant="outline" className="hidden sm:inline-flex">
+            <Link href="https://enhancemystay.com/login">Sign In</Link>
           </Button>
-          <Button className="hidden xs:inline-flex">Get Started</Button>
+          <Button asChild className="hidden xs:inline-flex">
+            <Link href="https://enhancemystay.com/register">Get Started</Link>
+          </Button>
 
           {/* Mobile Menu */}
           <div className="md:hidden">

--- a/components/navbar/navigation-sheet.tsx
+++ b/components/navbar/navigation-sheet.tsx
@@ -20,10 +20,12 @@ export const NavigationSheet = () => {
         <NavMenu orientation="vertical" className="mt-12" />
 
         <div className="mt-8 space-y-4">
-          <Button variant="outline" className="w-full sm:hidden">
-            Sign In
+          <Button asChild variant="outline" className="w-full sm:hidden">
+            <Link href="https://enhancemystay.com/login">Sign In</Link>
           </Button>
-          <Button className="w-full xs:hidden">Get Started</Button>
+          <Button asChild className="w-full xs:hidden">
+            <Link href="https://enhancemystay.com/register">Get Started</Link>
+          </Button>
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary
- point all Get Started buttons to EMS registration
- route Book a Demo CTAs to Calendly event
- link Sign In buttons to EMS login and update contact page's demo widget

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c15834e580832d8cde1f55428383f4