### PR TITLE
Add Contentful-powered blog

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,47 @@
+import { notFound } from 'next/navigation';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+import { getContentfulClient } from '@/lib/contentful';
+
+export const revalidate = 60;
+
+type BlogPostFields = {
+  title: string;
+  slug: string;
+  content: unknown;
+};
+
+export async function generateStaticParams() {
+  const client = getContentfulClient();
+  const res = await client.getEntries<BlogPostFields>({ content_type: 'blogPost' });
+  return res.items.map((post) => ({ slug: post.fields.slug }));
+}
+
+interface BlogPostPageProps {
+  params: { slug: string };
+}
+
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const client = getContentfulClient();
+  const res = await client.getEntries<BlogPostFields>({
+    content_type: 'blogPost',
+    limit: 1,
+    'fields.slug': params.slug,
+  });
+  const post = res.items[0];
+
+  if (!post) {
+    notFound();
+  }
+
+  return (
+    <article className="max-w-3xl mx-auto py-12">
+      <h1 className="text-3xl font-bold mb-6">{post.fields.title}</h1>
+      <div className="prose">
+        {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          documentToReactComponents(post.fields.content as any)
+        }
+      </div>
+    </article>
+  );
+}

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import { getContentfulClient } from '@/lib/contentful';
+
+export const revalidate = 60;
+
+type BlogPostFields = {
+  title: string;
+  slug: string;
+};
+
+export default async function BlogPage() {
+  const client = getContentfulClient();
+  const res = await client.getEntries<BlogPostFields>({ content_type: 'blogPost' });
+  const posts = res.items;
+
+  return (
+    <div className="max-w-3xl mx-auto py-12">
+      <h1 className="text-3xl font-bold mb-6">Blog</h1>
+      <ul className="space-y-4">
+        {posts.map((post) => (
+          <li key={post.sys.id}>
+            <Link
+              href={`/blog/${post.fields.slug}`}
+              className="text-xl text-blue-600 hover:underline"
+            >
+              {post.fields.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/navbar/nav-menu.tsx
+++ b/components/navbar/nav-menu.tsx
@@ -14,6 +14,9 @@ export const NavMenu = ({ orientation, className, ...props }: NavigationMenuProp
   if (orientation === "vertical") {
     return (
       <div className={cn("space-y-6", className)} {...props}>
+        <Link href="/blog" className="font-semibold">
+          Blog
+        </Link>
         <div>
           <p className="font-semibold">Features</p>
           <ul className="mt-2 ml-4 flex flex-col gap-2">
@@ -100,6 +103,11 @@ export const NavMenu = ({ orientation, className, ...props }: NavigationMenuProp
             </li>
           </ul>
         </NavigationMenuContent>
+      </NavigationMenuItem>
+      <NavigationMenuItem>
+        <NavigationMenuLink asChild>
+          <Link href="/blog">Blog</Link>
+        </NavigationMenuLink>
       </NavigationMenuItem>
     </NavigationMenuList>
     </NavigationMenu>

--- a/lib/contentful.ts
+++ b/lib/contentful.ts
@@ -1,0 +1,17 @@
+import { createClient, type ContentfulClientApi } from 'contentful';
+
+const createContentfulClient = (preview = false): ContentfulClientApi => {
+  return createClient({
+    space: process.env.CONTENTFUL_SPACE_ID ?? '',
+    environment: process.env.CONTENTFUL_ENVIRONMENT ?? 'master',
+    accessToken: preview
+      ? process.env.CONTENTFUL_PREVIEW_TOKEN ?? ''
+      : process.env.CONTENTFUL_DELIVERY_TOKEN ?? '',
+    host: preview ? 'preview.contentful.com' : 'cdn.contentful.com',
+  });
+};
+
+export const contentfulClient = createContentfulClient();
+export const contentfulPreviewClient = createContentfulClient(true);
+export const getContentfulClient = (preview = false) =>
+  preview ? contentfulPreviewClient : contentfulClient;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "motion": "^12.4.7",
     "next": "15.1.7",
     "lottie-react": "^2.4.0",
+    "contentful": "^10.0.0",
+    "@contentful/rich-text-react-renderer": "^15.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tailwind-merge": "^3.0.2",


### PR DESCRIPTION
## Summary
- configure Contentful client using environment variables
- list Contentful blog posts and link to individual pages
- render individual blog posts and add Blog link to navigation

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@contentful%2frich-text-react-renderer)*
- `npm run lint` *(fails: Parsing error: Expected corresponding JSX closing tag for 'section')*
- `npm run type-check` *(fails: Expected corresponding JSX closing tag for 'section')*

------
https://chatgpt.com/codex/tasks/task_e_68c15b032134832dbc886054697d6c0b