### PR TITLE
refactor: use Next.js Image for logos

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -3,6 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Linkedin } from "lucide-react";
 import Link from "next/link";
+import Image from "next/image";
 
 const productLinks = [
   { title: "Emails", href: "/emails" },
@@ -32,7 +33,13 @@ const Footer = () => {
           <div>
             {/* Logo */}
             <Link href="/">
-              <img src="/EMSLogoWhite.png" alt="EMS logo" className="h-8 w-auto" />
+              <Image
+                src="/EMSLogoWhite.png"
+                alt="EMS logo"
+                width={844}
+                height={297}
+                className="h-8 w-auto"
+              />
             </Link>
 
             <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-6 text-sm">

--- a/components/navbar/logo.tsx
+++ b/components/navbar/logo.tsx
@@ -1,3 +1,11 @@
+import Image from "next/image";
+
 export const Logo = () => (
-  <img src="/emslogo.png" alt="Logo" className="h-8 w-auto" />
+  <Image
+    src="/emslogo.png"
+    alt="Logo"
+    width={177}
+    height={62}
+    className="h-8 w-auto"
+  />
 );


### PR DESCRIPTION
## Summary
- switch footer logo from `<img>` to `next/image`
- use `next/image` for navbar logo

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c15c958578832d921a1717066c464d