### PR TITLE
Refine hero and pricing visuals, fix blog page params type

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -13,9 +13,9 @@ type BlogPost = {
 };
 
 interface BlogPostPageProps {
-  params: {
+  params: Promise<{
     slug: string;
-  };
+  }>;
 }
 
 export async function generateStaticParams() {
@@ -24,7 +24,8 @@ export async function generateStaticParams() {
   return items.map((post: BlogPost) => ({ slug: post.fields.slug }));
 }
 
-export default async function BlogPostPage({ params: { slug } }: BlogPostPageProps) {
+export default async function BlogPostPage({ params }: BlogPostPageProps) {
+  const { slug } = await params;
   const entries = await client.getEntries({
     content_type: "blogPost",
     "fields.slug": slug,

--- a/components/features.tsx
+++ b/components/features.tsx
@@ -187,12 +187,12 @@ const Features = () => {
       <div className="w-full max-w-screen-lg mx-auto mt-10 sm:mt-16">
         <div className="grid md:grid-cols-2 gap-6 items-center">
           <Image
-  src="/EMSUpsellSite.png"
-  alt="EMS Upsell Site"
-  width={800}
-  height={600}
-  className="w-full max-w-md lg:max-w-lg xl:max-w-xl h-auto rounded-xl shadow-md"
-/>
+            src="/EMSUpsellSite.png"
+            alt="EMS Upsell Site"
+            width={800}
+            height={600}
+            className="w-full max-w-md lg:max-w-lg xl:max-w-xl h-auto max-h-[520px]"
+          />
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
             {howItWorks.map((item) => (
               <FeatureCard key={item.title} icon={item.icon} title={item.title}>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -52,11 +52,11 @@ const Hero = () => {
 
         {/* Right column: hero image */}
         <div className="md:w-1/2 flex justify-center items-stretch mt-10 md:mt-0">
-          <div className="flex items-center w-full max-w-sm lg:max-w-md xl:max-w-lg">
+          <div className="flex items-center w-full max-w-xs sm:max-w-sm md:max-w-md">
             <Image
               src={heroImage}
               alt="EMS Hero"
-              className="w-full h-auto max-h-full object-contain rounded-3xl"
+              className="w-full h-auto max-h-[420px] object-contain rounded-3xl"
               priority
             />
           </div>

--- a/components/pricing.tsx
+++ b/components/pricing.tsx
@@ -23,17 +23,17 @@ export default function Pricing() {
     <Section id="pricing">
       <div>
         <div className="mt-8 w-full flex justify-center">
-          <Card className="p-8 flex flex-col items-center text-center max-w-lg">
+          <Card className="p-8 flex flex-col items-center text-center max-w-md">
             <div className="flex items-baseline justify-center gap-2">
               <span className="text-5xl font-bold">£59</span>
-              <span className="text-lg font-semibold">/ property / month + VAT</span>
+              <span className="text-sm font-normal">/ property / month + VAT</span>
             </div>
 
             <div className="mt-8 w-full">
               <h2 className="text-xl font-semibold">What’s included (per property):</h2>
-              <ul className="mt-4 space-y-2 text-sm md:text-base">
+              <ul className="mt-4 space-y-2 text-sm md:text-base text-center">
                 {included.map((item) => (
-                  <li key={item} className="flex flex-col items-center gap-2">
+                  <li key={item} className="flex items-center justify-center gap-2">
                     <Check className="h-4 w-4 text-primary" />
                     <span>{item}</span>
                   </li>
@@ -43,7 +43,7 @@ export default function Pricing() {
 
             <div className="mt-8 w-full">
               <h2 className="text-xl font-semibold">Processing & billing:</h2>
-              <ul className="mt-4 space-y-1 text-sm md:text-base list-none">
+              <ul className="mt-4 space-y-1 text-sm md:text-base list-none text-center">
                 <li>Payments taken via our checkout incur a 3.5% processing fee.</li>
                 <li>All plans charged + VAT.</li>
                 <li>Extra properties enjoy a 25% discount</li>


### PR DESCRIPTION
## Summary
- Scale down hero image for better balance with text
- Simplify "How It Works" illustration and match card stack height
- Center and tighten pricing card content with adjusted typography
- Treat blog post route params as async to satisfy Next.js 15 typings

## Testing
- `npm run lint`
- `npm run type-check`
- `CONTENTFUL_SPACE_ID=foo CONTENTFUL_DELIVERY_TOKEN=bar npm run build` *(fails: 403 Forbidden from Contentful)*

------
https://chatgpt.com/codex/tasks/task_e_68c2806c28d0832d92108963ee612f74