### PR TITLE
Reduce desktop hero image size for better layout balance

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -52,11 +52,11 @@ const Hero = () => {
 
         {/* Right column: hero image */}
         <div className="md:w-1/2 flex justify-center items-stretch mt-10 md:mt-0">
-          <div className="flex items-center w-full max-w-xs sm:max-w-sm md:max-w-md">
+          <div className="flex items-center w-full max-w-xs sm:max-w-sm md:max-w-sm">
             <Image
               src={heroImage}
               alt="EMS Hero"
-              className="w-full h-auto max-h-[420px] object-contain rounded-3xl"
+              className="w-full h-auto max-h-[420px] md:max-h-[360px] object-contain rounded-3xl"
               priority
             />
           </div>


### PR DESCRIPTION
## Summary
- scale down hero image on desktop to better match left-side content height

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run type-check`
- `npm run build` *(fails: Failed to collect configuration for /blog: Expected parameter accessToken)*

------
https://chatgpt.com/codex/tasks/task_e_68c289fb0148832dbb6dcc08c5edc041